### PR TITLE
Add initial guess as centroid

### DIFF
--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -701,7 +701,7 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
         if mean_shift > 0:
             mu_k[mean_shift:] = vec[:-mean_shift, -1].reshape((sz - mean_shift, 1))
         elif mean_shift < 0:
-            mu_k[:mean_shift] = vec[-mean_shift:, -1].reshape((sz + mean_shift, 1)) 
+            mu_k[:mean_shift] = vec[-mean_shift:, -1].reshape((sz + mean_shift, 1))
         else:
             mu_k = vec[:, -1].reshape((sz, 1))
 
@@ -732,12 +732,15 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
 
     def _fit_one_init(self, X, rs):
         n_samples, sz, d = X.shape
-        self.labels_ = rs.randint(self.n_clusters, size=n_samples)
         if hasattr(self.init, '__array__'):
             self.cluster_centers_ = self.init.copy()
         else:
             self.cluster_centers_ = rs.randn(self.n_clusters, sz, d)
         self._norms_centroids = numpy.linalg.norm(self.cluster_centers_, axis=(1, 2))
+        if hasattr(self.init, '__array__'):
+            self._assign(X)
+        else:
+            self.labels_ = rs.randint(self.n_clusters, size=n_samples)
         old_inertia = numpy.inf
 
         for it in range(self.max_iter):

--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -704,11 +704,11 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
         _check_no_empty_cluster(self.labels_, self.n_clusters)
         self.inertia_ = _compute_inertia(dists, self.labels_)
 
-    def _fit_one_init(self, X, initial_guess, rs):
+    def _fit_one_init(self, X, initial_centroids, rs):
         n_samples, sz, d = X.shape
         self.labels_ = rs.randint(self.n_clusters, size=n_samples)
-        if initial_guess is not None:
-            self.cluster_centers_ = X[initial_guess]
+        if initial_centroids is not None:
+            self.cluster_centers_ = initial_centroids.copy()
         else:
             self.cluster_centers_ = rs.randn(self.n_clusters, sz, d)
         self._norms_centroids = numpy.linalg.norm(self.cluster_centers_, axis=(1, 2))
@@ -734,24 +734,27 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
 
         return self
 
-    def fit(self, X, initial_guess, y=None):
+    def fit(self, X, initial_centroids=None, y=None):
         """Compute k-Shape clustering.
 
         Parameters
         ----------
         X : array-like of shape=(n_ts, sz, d)
             Time series dataset.
-        initial_guess: array-like of shape=(n_clusters)
-            IntArray of indices.
+        initial_centroids: array-like of shape=(n_clusters, sz, d) of initial centroids
+            Time series dataset.
         """
 
         X_ = to_time_series_dataset(X)
         self._norms = numpy.linalg.norm(X_, axis=(1, 2))
-        X_ = TimeSeriesScalerMeanVariance(mu=0., std=1.).fit_transform(X_)
+
         assert X_.shape[-1] == 1, "kShape is supposed to work on monomodal data, provided data has dimension %d" % \
                                   X_.shape[-1]
-        if initial_guess is not None:
-            assert len(initial_guess) == self.n_clusters, "Initial guess index array must contain {}, {} given".format(self.n_clusters, len(initial_guess))
+        if initial_centroids is not None:
+            assert initial_centroids.shape[-1] == 1, "kShape is supposed to work on monomodal data, provided data has dimension %d" % \
+                                      X_.shape[-1]
+            assert initial_centroids.shape[0] == self.n_clusters, "Initial guess index array must contain {}, {} given".format(self.n_clusters, initial_centroids.shape[0])
+
         rs = check_random_state(self.random_state)
 
         best_correct_centroids = None
@@ -763,7 +766,7 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
                 if self.verbose and self.n_init > 1:
                     print("Init %d" % (n_successful + 1))
                 n_attempts += 1
-                self._fit_one_init(X_, initial_guess, rs)
+                self._fit_one_init(X_, initial_centroids, rs)
                 if self.inertia_ < min_inertia:
                     best_correct_centroids = self.cluster_centers_.copy()
                     min_inertia = self.inertia_
@@ -775,7 +778,7 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
         self._norms_centroids = numpy.linalg.norm(self.cluster_centers_, axis=(1, 2))
         return self
 
-    def fit_predict(self, X, initial_guess=None, y=None):
+    def fit_predict(self, X, initial_centroids=None, y=None):
         """Fit k-Shape clustering using X and then predict the closest cluster each time series in X belongs to.
 
         It is more efficient to use this method than to sequentially call fit and predict.
@@ -784,15 +787,15 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
         ----------
         X : array-like of shape=(n_ts, sz, d)
             Time series dataset to predict.
-        initial_guess: array-like of shape=(n_clusters)
-            IntArray of indices.
+        initial_centroids: array-like of shape=(n_clusters, sz, d) of initial centroids
+            Time series dataset.
 
         Returns
         -------
         labels : array of shape=(n_ts, )
             Index of the cluster each sample belongs to.
         """
-        return self.fit(X, initial_guess).labels_
+        return self.fit(X, initial_centroids).labels_
 
     def predict(self, X):
         """Predict the closest cluster each time series in X belongs to.

--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -156,6 +156,14 @@ def silhouette_score(X, labels, metric=None, sample_size=None, metric_params=Non
                                     **kwds)
 
 
+def _check_initial_guess(init, X, n_clusters):
+    if hasattr(init, '__array__'):
+        assert init.shape[-1] == 1, "kMeans is supposed to work on monomodal data, " \
+                                    "provided data has dimension {}".format(X.shape[-1])
+        assert init.shape[0] == n_clusters, "Initial guess index array must contain {} samples," \
+                                            " {} given".format(n_clusters, init.shape[0])
+
+
 class GlobalAlignmentKernelKMeans(BaseEstimator, ClusterMixin):
     """Global Alignment Kernel K-means.
 
@@ -545,13 +553,7 @@ class TimeSeriesKMeans(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClust
         rs = check_random_state(self.random_state)
         x_squared_norms = cdist(X_.reshape((X_.shape[0], -1)), numpy.zeros((1, X_.shape[1] * X_.shape[2])),
                                 metric="sqeuclidean").reshape((1, -1))
-
-        if hasattr(self.init, '__array__'):
-            assert self.init.shape[-1] == 1, "kMeans is supposed to work on monomodal data, " \
-                                             "provided data has dimension {}".format(X_.shape[-1])
-            assert self.init.shape[0] == self.n_clusters, "Initial guess index array must contain {} samples," \
-                                                          " {} given".format(self.n_clusters,
-                                                                             self.init.shape[0])
+        _check_initial_guess(self.init, X_, self.n_clusters)
 
         best_correct_centroids = None
         min_inertia = numpy.inf
@@ -777,12 +779,7 @@ class KShape(BaseEstimator, ClusterMixin, TimeSeriesCentroidBasedClusteringMixin
 
         assert X_.shape[-1] == 1, "kShape is supposed to work on monomodal data, provided data has " \
                                   "dimension {}".format(X_.shape[-1])
-        if hasattr(self.init, '__array__'):
-            assert self.init.shape[-1] == 1, "kShape is supposed to work on monomodal data, provided data " \
-                                             "has dimension {}".format(X_.shape[-1])
-            assert self.init.shape[0] == self.n_clusters, "Initial guess index array must contain {}, " \
-                                                          "{} given".format(self.n_clusters,
-                                                                            self.init.shape[0])
+        _check_initial_guess(self.init, X_, self.n_clusters)
 
         rs = check_random_state(self.random_state)
 

--- a/tslearn/cycc.pyx
+++ b/tslearn/cycc.pyx
@@ -74,6 +74,7 @@ def y_shifted_sbd_vec(numpy.ndarray[DTYPE_t, ndim=2] ref_ts, numpy.ndarray[DTYPE
                       numpy.ndarray[DTYPE_t, ndim=1] norms_dataset):
     assert dataset.dtype == DTYPE and ref_ts.dtype == DTYPE
     assert dataset.shape[1] == ref_ts.shape[0] and dataset.shape[2] == ref_ts.shape[1]
+    cdef int shift_mean = 0
     cdef int i = 0
     cdef int sz = dataset.shape[1]
     cdef numpy.ndarray[DTYPE_t, ndim=3] dataset_shifted = numpy.zeros((dataset.shape[0], dataset.shape[1],
@@ -99,4 +100,10 @@ def y_shifted_sbd_vec(numpy.ndarray[DTYPE_t, ndim=2] ref_ts, numpy.ndarray[DTYPE
             dataset_shifted[i, :shift] = dataset[i, -shift:, :]
         else:
             dataset_shifted[i] = dataset[i]
-    return dataset_shifted
+
+        shift_mean = shift_mean + shift
+
+    if dataset.shape[0] > 0:
+        shift_mean = shift_mean/dataset.shape[0]
+
+    return dataset_shifted, shift_mean

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -133,7 +133,7 @@ class TimeSeriesScalerMeanVariance(TransformerMixin):
         self.global_mean = None
         self.global_std = None
 
-    def fit_transform(self, X, global_stats=False, **kwargs):
+    def fit_transform(self, X, **kwargs):
         """Fit to data, then transform it.
 
         Parameters


### PR DESCRIPTION
According to the issue #58 , here a proposal to improve clustering (only for the KShape method for now) by letting the user choose an initial guess as centroids. This guess is a numpy array of int which are the indices of the samples to be used as centroids instead of a random vector.