### PR TITLE
fix index out of bounds II (based on #60)

### DIFF
--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -320,6 +320,8 @@ def ts_size(ts):
     3
     >>> ts_size([[1, 2], [2, 3], [3, 4], [numpy.nan, 2], [numpy.nan, numpy.nan]])
     4
+    >>> ts_size([[numpy.nan, numpy.nan], [3, 4]])
+    1
     """
     ts_ = to_time_series(ts)
     return sum(numpy.any(numpy.isfinite(ts_), axis=1))

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -322,10 +322,7 @@ def ts_size(ts):
     4
     """
     ts_ = to_time_series(ts)
-    sz = ts_.shape[0]
-    while not numpy.any(numpy.isfinite(ts_[sz - 1])):
-        sz -= 1
-    return sz
+    return sum(numpy.any(numpy.isfinite(ts_), axis=1))
 
 
 def ts_zeros(sz, d=1):


### PR DESCRIPTION
based on PR #60 

* ts_size([[numpy.nan, numpy.nan], [3, 4]]) would have returned 2 in the past, returns 1 now.
* converted code to numpy, 1 single line now (not sure whether it works faster)
* did not find an example where an IndexOutOfBoundsError occurred though (which was the original reason behind the creation of this PR)...