### PR TITLE
Fixed loading of some UCR datasets by additional string parsing

### DIFF
--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -331,3 +331,13 @@ class CachedDatasets(object):
         y_train = npzfile["y_train"]
         y_test = npzfile["y_test"]
         return X_train, y_train, X_test, y_test
+
+if __name__ == "__main__":
+    # test load all datasets
+    dataset = UCR_UEA_datasets()
+    for dataset_name in dataset.list_datasets():
+        X_train, y_train, X_test, y_test = dataset.load_dataset(dataset_name)
+        if (X_train is None) or (X_test is None) or (y_train is None) or (y_test is None):
+            print("Dataset {0: <40}: failure!".format(dataset_name))
+        else:
+            print("Dataset {0: <40}: success!".format(dataset_name))

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -147,8 +147,6 @@ class UCR_UEA_datasets(object):
         except:
             self._baseline_scores_filename = None
 
-        if self._baseline_scores_filename is not None:
-
         self._ignore_list = ["Data Descriptions"]
 
     def baseline_accuracy(self, list_datasets=None, list_methods=None):
@@ -262,7 +260,7 @@ class UCR_UEA_datasets(object):
                     os.remove(os.path.join(full_path, fname))
             extract_from_zip_url(url, target_dir=self._data_dir, verbose=False)
 
-	data_train = numpy.loadtxt(os.path.join(full_path, fname_train), delimiter=",")
+        data_train = numpy.loadtxt(os.path.join(full_path, fname_train), delimiter=",")
         data_test = numpy.loadtxt(os.path.join(full_path, fname_test), delimiter=",")
 
         X_train = to_time_series_dataset(data_train[:, 1:])

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -23,8 +23,9 @@ from tslearn.utils import to_time_series_dataset
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 def harmonize_dataset_filenames(folder, verbose=False):
-    """Makes sure that dataset name and filename-prefix are the same, as expected by UCR_UEA_datasets.load_dataset()
-    Also removes .DS_Store files if exist (e.g., in uWaveGestureLibrary_Y)
+    """This function ensures that the dataset name and prefix of the filename are equal.
+    This is expected by UCR_UEA_datasets.load_dataset() function.
+    It also removes temporary files in the dataset (e.g., .DS_Store in uWaveGestureLibrary_Y)
 
     Parameters
     ----------
@@ -40,12 +41,20 @@ def harmonize_dataset_filenames(folder, verbose=False):
     if os.path.exists(os.path.join(folder, ".DS_Store")):
         os.remove(os.path.join(folder, ".DS_Store"))
 
-    for f in os.listdir(folder):
-        if not f.startswith(dataset_name):
-            new_f = dataset_name + "_" + f.split("_")[-1]
+    for filename in os.listdir(folder):
 
-            os.rename(os.path.join(folder,f), os.path.join(folder,new_f))
-            if verbose: print("fixed " + os.path.join(folder, f) + "->" + os.path.join(folder, new_f))
+        # test if prefix separated by "_" is equal to dataset name
+        if not filename.startswith(dataset_name):
+
+            # parse correct dataset name
+            suffix = filename.split("_")[-1] # e.g. TRAIN.txt
+            new_filename = dataset_name + "_" + suffix
+
+            # rename file
+            os.rename(os.path.join(folder,filename), os.path.join(folder,new_filename))
+
+            if verbose:
+                print("fixed " + os.path.join(folder, filename) + "->" + os.path.join(folder, new_filename))
 
 
 def extract_from_zip_url(url, target_dir=None, verbose=False):

--- a/tslearn/datasets.py
+++ b/tslearn/datasets.py
@@ -24,8 +24,7 @@ __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 def harmonize_dataset_filenames(folder, verbose=False):
     """This function ensures that the dataset name and prefix of the filename are equal.
-    This is expected by UCR_UEA_datasets.load_dataset() function.
-    It also removes temporary files in the dataset (e.g., .DS_Store in uWaveGestureLibrary_Y)
+    This property is expected later by load dataset function.
 
     Parameters
     ----------


### PR DESCRIPTION
I noticed that some datasets did not load correctly. These datasets return `None` instead of numpy arrays. Reasons were mostly inconsistcies between dataset names (defined in the first column of `http://www.timeseriesclassification.com/singleTrainTest.csv`) and filenames in the downloaded ZIP files. 

Two changes fixed the failed loading attempts:

(1) Fixed loading of some _UCR UEA datasets_ `Wafer`, `Yoga`, `UWaveGestureLibrary{X,Y,Z}`, `Fish`, `Mallat` by adding a string parsing function `harmonize_dataset_filenames` that ensures that datafiles follow a common naming convention (e.g.,` <datasetname>_TRAIN.txt`).  

(2) Added typo-fix in `http://www.timeseriesclassification.com/singleTrainTest.csv` after download by in-file string replacement with the new `inplace_change`-function.
This corrects "Fatal" to "Fetal" in the `NonInvasiveFetalECGThorax{1,2}` datasets and changes the download url to the correct `http://www.timeseriesclassification.com/Downloads/NonInvasiveFetalECGThorax1.zip`.

Minor changes:

* Removed `self._filenames`-dictionary: The changes (1) and (2) made this dictionary obsolete (it originally recorded filename anomalies).

* Added doctests for datasets that previously failed (`Fish` and `NonInvasiveFetalECGThorax1`)