### PR TITLE
Increase training and inference performance for GAK kernel

### DIFF
--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -40,7 +40,7 @@ def _sparse_kernel_func_gak(sz, d, gamma, slice_support_vectors=None):
         
         if X is X_fit:
             X = X.reshape((-1, sz, d))
-            return cdist_gak(X, X, sigma=numpy.sqrt(gamma / 2.))
+            return cdist_gak(X, None, sigma=numpy.sqrt(gamma / 2.))
         
         if slice_support_vectors is not None:
             # slice out support vectors and only compute cross sim with them
@@ -173,6 +173,7 @@ class TimeSeriesSVC(BaseSVC):
         self.d = d
         if kernel == "gak":
             kernel = _sparse_kernel_func_gak(sz=sz, d=d, gamma=gamma)
+            # kernel = _kernel_func_gak(sz=sz, d=d, gamma=gamma)
         super(TimeSeriesSVC, self).__init__(C=C, kernel=kernel, degree=degree, gamma=gamma, coef0=coef0,
                                             shrinking=shrinking, probability=probability, tol=tol,
                                             cache_size=cache_size, class_weight=class_weight, verbose=verbose,
@@ -193,8 +194,10 @@ class TimeSeriesSVC(BaseSVC):
         sklearn_X = _prepare_ts_datasets_sklearn(X)
         if self.kernel == "gak" and self.gamma == "auto":
             self.gamma = gamma_soft_dtw(to_time_series_dataset(X))
+            # self.kernel = _kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
             self.kernel = _sparse_kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
         _self = super(TimeSeriesSVC, self).fit(sklearn_X, y, sample_weight=sample_weight)
+        # self.kernel = _kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
         self.kernel = _sparse_kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma, slice_support_vectors=self.support_)
         return _self
 

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -32,6 +32,30 @@ def _kernel_func_gak(sz, d, gamma):
         gamma = 1.
     return lambda x, y: cdist_gak(x.reshape((-1, sz, d)), y.reshape((-1, sz, d)), sigma=numpy.sqrt(gamma / 2.))
 
+def _sparse_kernel_func_gak(sz, d, gamma, slice_support_vectors=None):
+    if gamma == "auto":
+        gamma = 1.
+    
+    def sparse_gak(X, X_fit):
+        
+        if X is X_fit:
+            X = X.reshape((-1, sz, d))
+            return cdist_gak(X, X, sigma=numpy.sqrt(gamma / 2.))
+        
+        if slice_support_vectors is not None:
+            # slice out support vectors and only compute cross sim with them
+            sliced_X_fit = X_fit[slice_support_vectors]
+            gak_sim_dense = cdist_gak(X.reshape((-1, sz, d)), sliced_X_fit.reshape((-1, sz, d)), sigma=numpy.sqrt(gamma / 2.))
+
+            # act like nothing has happend ...
+            gak_sim = numpy.empty((len(X), len(X_fit)))
+            gak_sim[:, slice_support_vectors] = gak_sim_dense
+            
+            return gak_sim
+        
+        return cdist_gak(X.reshape((-1, sz, d)), X_fit.reshape((-1, sz, d)), sigma=numpy.sqrt(gamma / 2.))
+
+    return sparse_gak
 
 class TimeSeriesSVC(BaseSVC):
     """Time-series specific Support Vector Classifier.
@@ -148,7 +172,7 @@ class TimeSeriesSVC(BaseSVC):
         self.sz = sz
         self.d = d
         if kernel == "gak":
-            kernel = _kernel_func_gak(sz=sz, d=d, gamma=gamma)
+            kernel = _sparse_kernel_func_gak(sz=sz, d=d, gamma=gamma)
         super(TimeSeriesSVC, self).__init__(C=C, kernel=kernel, degree=degree, gamma=gamma, coef0=coef0,
                                             shrinking=shrinking, probability=probability, tol=tol,
                                             cache_size=cache_size, class_weight=class_weight, verbose=verbose,
@@ -169,8 +193,10 @@ class TimeSeriesSVC(BaseSVC):
         sklearn_X = _prepare_ts_datasets_sklearn(X)
         if self.kernel == "gak" and self.gamma == "auto":
             self.gamma = gamma_soft_dtw(to_time_series_dataset(X))
-            self.kernel = _kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
-        return super(TimeSeriesSVC, self).fit(sklearn_X, y, sample_weight=sample_weight)
+            self.kernel = _sparse_kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
+        _self = super(TimeSeriesSVC, self).fit(sklearn_X, y, sample_weight=sample_weight)
+        self.kernel = _sparse_kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma, slice_support_vectors=self.support_)
+        return _self
 
     def predict(self, X):
         sklearn_X = _prepare_ts_datasets_sklearn(X)

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -173,7 +173,6 @@ class TimeSeriesSVC(BaseSVC):
         self.d = d
         if kernel == "gak":
             kernel = _sparse_kernel_func_gak(sz=sz, d=d, gamma=gamma)
-            # kernel = _kernel_func_gak(sz=sz, d=d, gamma=gamma)
         super(TimeSeriesSVC, self).__init__(C=C, kernel=kernel, degree=degree, gamma=gamma, coef0=coef0,
                                             shrinking=shrinking, probability=probability, tol=tol,
                                             cache_size=cache_size, class_weight=class_weight, verbose=verbose,
@@ -194,10 +193,8 @@ class TimeSeriesSVC(BaseSVC):
         sklearn_X = _prepare_ts_datasets_sklearn(X)
         if self.kernel == "gak" and self.gamma == "auto":
             self.gamma = gamma_soft_dtw(to_time_series_dataset(X))
-            # self.kernel = _kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
             self.kernel = _sparse_kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
         _self = super(TimeSeriesSVC, self).fit(sklearn_X, y, sample_weight=sample_weight)
-        # self.kernel = _kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma)
         self.kernel = _sparse_kernel_func_gak(sz=self.sz, d=self.d, gamma=self.gamma, slice_support_vectors=self.support_)
         return _self
 


### PR DESCRIPTION
Hi! I've been using the `TimeSeriesSVC` with the `gak` kernel for a while now and I've made some changes that increased the performance quite a bit, the most time consuming part in my case was computing the kernel and its there where I've made some changes

### Changes that apply to training:

To compute the self-similarity, scikit-learn evaluates the [callable kernel using a reference of X](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/svm/base.py#L251) as the second argument, in the [current implementation will check if the second argument is `None`](https://github.com/rtavenar/tslearn/blob/master/tslearn/metrics.py#L353) which it isn't, hence it computes everything twice

### Changes that apply to inference:

When doing prediction, [scikit-learn evaluates the callable kernel for every point (`X_fit`) seen up until then](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/svm/base.py#L331), but the only thing  libsvm really needs is the distance to its support vectors, hence we can omit computing the others.