### PR TITLE
[WIP] Accept variable-length time series for some pairs metrics/estimators

### DIFF
--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -317,7 +317,7 @@ class GlobalAlignmentKernelKMeans(BaseEstimator, ClusterMixin):
             default, all time series weights are equal.
         """
 
-        X = check_array(X, allow_nd=True)
+        X = check_array(X, allow_nd=True, force_all_finite=False)
         X = check_dims(X, X_fit=None)
 
         if sample_weight is not None:
@@ -419,7 +419,7 @@ class GlobalAlignmentKernelKMeans(BaseEstimator, ClusterMixin):
         labels : array of shape=(n_ts, )
             Index of the cluster each sample belongs to.
         """
-        X = check_array(X, allow_nd=True)
+        X = check_array(X, allow_nd=True, force_all_finite=False)
         check_is_fitted(self, '_X_fit')
         X = check_dims(X, self._X_fit)
         K = self._get_kernel(X, self._X_fit)
@@ -427,6 +427,9 @@ class GlobalAlignmentKernelKMeans(BaseEstimator, ClusterMixin):
         dist = numpy.zeros((n_samples, self.n_clusters))
         self._compute_dist(K, dist)
         return dist.argmin(axis=1)
+
+    def _get_tags(self):
+        return {'allow_nan': True, 'allow_variable_length': True}
 
 
 class TimeSeriesCentroidBasedClusteringMixin:
@@ -727,7 +730,7 @@ class TimeSeriesKMeans(BaseEstimator, ClusterMixin,
         return self._assign(X_, update_class_attributes=False)
 
     def _get_tags(self):
-        return {'allow_nan': True}
+        return {'allow_nan': True, 'allow_variable_length': True}
 
 
 class KShape(BaseEstimator, ClusterMixin,

--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -223,8 +223,10 @@ class GlobalAlignmentKernelKMeans(BaseEstimator, ClusterMixin):
         Number of time the k-means algorithm will be run with different
         centroid seeds. The final results will be the
         best output of n_init consecutive runs in terms of inertia.
-    sigma : float (default: 1.)
-        Bandwidth parameter for the Global Alignment kernel
+    sigma : float or "auto" (default: "auto")
+        Bandwidth parameter for the Global Alignment kernel. If set to 'auto',
+        it is computed based on a sampling of the training set
+        (cf :ref:`tslearn.metrics.sigma_gak <fun-sigmagak>`)
     verbose : bool (default: False)
         Whether or not to print information about the inertia while learning
         the model.

--- a/tslearn/docs/examples/plot_barycenter_interpolate.py
+++ b/tslearn/docs/examples/plot_barycenter_interpolate.py
@@ -18,7 +18,7 @@ import matplotlib.pyplot as plt
 import matplotlib.colors
 
 from tslearn.preprocessing import TimeSeriesScalerMinMax
-from tslearn.barycenters import SoftDTWBarycenter
+from tslearn.barycenters import softdtw_barycenter
 from tslearn.datasets import CachedDatasets
 
 
@@ -69,7 +69,7 @@ for pos in range(2, 25):
     w[1] = (4 - idxr) * idxc / 16
     w[2] = idxr * (4 - idxc) / 16
     w[3] = idxr * idxc / 16
-    plt.plot(SoftDTWBarycenter(weights=w).fit(X_out).ravel(),
+    plt.plot(softdtw_barycenter(X=X_out, weights=w).ravel(),
              color=matplotlib.colors.rgb2hex(get_color(w)),
              linewidth=2)
     plt.xticks([])

--- a/tslearn/docs/examples/plot_svm.py
+++ b/tslearn/docs/examples/plot_svm.py
@@ -27,9 +27,7 @@ X_train = TimeSeriesScalerMinMax().fit_transform(X_train)
 X_test = TimeSeriesScalerMinMax().fit_transform(X_test)
 
 clf = TimeSeriesSVC(kernel="gak",
-                    gamma=.1,
-                    sz=X_train.shape[1],
-                    d=X_train.shape[2])
+                    gamma=.1)
 clf.fit(X_train, y_train)
 print("Correct classification rate:", clf.score(X_test, y_test))
 

--- a/tslearn/docs/gen_modules/backreferences/tslearn.barycenters.softdtw_barycenter.examples
+++ b/tslearn/docs/gen_modules/backreferences/tslearn.barycenters.softdtw_barycenter.examples
@@ -20,3 +20,21 @@ Examples using ``tslearn.barycenters.softdtw_barycenter``
 .. only:: not html
 
     * :ref:`sphx_glr_auto_examples_plot_barycenters.py`
+
+.. raw:: html
+
+    <div class="sphx-glr-thumbcontainer" tooltip="This example presents the weighted Soft-DTW time series barycenter method.">
+
+.. only:: html
+
+    .. figure:: /auto_examples/images/thumb/sphx_glr_plot_barycenter_interpolate_thumb.png
+
+        :ref:`sphx_glr_auto_examples_plot_barycenter_interpolate.py`
+
+.. raw:: html
+
+    </div>
+
+.. only:: not html
+
+    * :ref:`sphx_glr_auto_examples_plot_barycenter_interpolate.py`

--- a/tslearn/docs/gen_modules/backreferences/tslearn.datasets.CachedDatasets.examples
+++ b/tslearn/docs/gen_modules/backreferences/tslearn.datasets.CachedDatasets.examples
@@ -5,6 +5,24 @@ Examples using ``tslearn.datasets.CachedDatasets``
 
 .. raw:: html
 
+    <div class="sphx-glr-thumbcontainer" tooltip="This example illustrates the use of the global alignment kernel for support vector classificati...">
+
+.. only:: html
+
+    .. figure:: /auto_examples/images/thumb/sphx_glr_plot_svm_thumb.png
+
+        :ref:`sphx_glr_auto_examples_plot_svm.py`
+
+.. raw:: html
+
+    </div>
+
+.. only:: not html
+
+    * :ref:`sphx_glr_auto_examples_plot_svm.py`
+
+.. raw:: html
+
     <div class="sphx-glr-thumbcontainer" tooltip="This example performs a :math:`k`-Nearest-Neighbor search in a database of time series using DT...">
 
 .. only:: html
@@ -38,24 +56,6 @@ Examples using ``tslearn.datasets.CachedDatasets``
 .. only:: not html
 
     * :ref:`sphx_glr_auto_examples_plot_kshape.py`
-
-.. raw:: html
-
-    <div class="sphx-glr-thumbcontainer" tooltip="This example illustrates the use of the global alignment kernel for support vector classificati...">
-
-.. only:: html
-
-    .. figure:: /auto_examples/images/thumb/sphx_glr_plot_svm_thumb.png
-
-        :ref:`sphx_glr_auto_examples_plot_svm.py`
-
-.. raw:: html
-
-    </div>
-
-.. only:: not html
-
-    * :ref:`sphx_glr_auto_examples_plot_svm.py`
 
 .. raw:: html
 

--- a/tslearn/docs/gen_modules/barycenters/tslearn.barycenters.dtw_barycenter_averaging.rst
+++ b/tslearn/docs/gen_modules/barycenters/tslearn.barycenters.dtw_barycenter_averaging.rst
@@ -1,3 +1,5 @@
+.. _fun-dba:
+
 tslearn.barycenters.dtw_barycenter_averaging
 ============================================
 

--- a/tslearn/docs/gen_modules/barycenters/tslearn.barycenters.softdtw_barycenter.rst
+++ b/tslearn/docs/gen_modules/barycenters/tslearn.barycenters.softdtw_barycenter.rst
@@ -1,3 +1,5 @@
+.. _fun-softdtwbar:
+
 tslearn.barycenters.softdtw_barycenter
 ======================================
 

--- a/tslearn/docs/gen_modules/metrics/tslearn.metrics.gamma_soft_dtw.rst
+++ b/tslearn/docs/gen_modules/metrics/tslearn.metrics.gamma_soft_dtw.rst
@@ -1,3 +1,5 @@
+.. _fun-gammasoftdtw:
+
 tslearn.metrics.gamma_soft_dtw
 ==============================
 

--- a/tslearn/docs/gen_modules/metrics/tslearn.metrics.sigma_gak.rst
+++ b/tslearn/docs/gen_modules/metrics/tslearn.metrics.sigma_gak.rst
@@ -1,3 +1,5 @@
+.. _fun-sigmagak:
+
 tslearn.metrics.sigma_gak
 =========================
 

--- a/tslearn/docs/gen_modules/svm/tslearn.svm.TimeSeriesSVC.rst
+++ b/tslearn/docs/gen_modules/svm/tslearn.svm.TimeSeriesSVC.rst
@@ -1,3 +1,5 @@
+.. _class-svc:
+
 tslearn.svm.TimeSeriesSVC
 =========================
 

--- a/tslearn/docs/gen_modules/svm/tslearn.svm.TimeSeriesSVR.rst
+++ b/tslearn/docs/gen_modules/svm/tslearn.svm.TimeSeriesSVR.rst
@@ -1,3 +1,5 @@
+.. _class-svr:
+
 tslearn.svm.TimeSeriesSVR
 =========================
 

--- a/tslearn/docs/variablelength.rst
+++ b/tslearn/docs/variablelength.rst
@@ -1,14 +1,52 @@
 Methods for variable-length time series datasets
 ================================================
 
-This page lists machine learning methods in `tslearn` that are able to deal with datasets containing time series of different lengths.
-We also provide example usage for these methods using the following variable-length time series dataset:
+This page lists machine learning methods in `tslearn` that are able to deal
+with datasets containing time series of different lengths.
+We also provide example usage for these methods using the following
+variable-length time series dataset:
 
 .. code-block:: python
 
     from tslearn.utils import to_time_series_dataset
     X = to_time_series_dataset([[1, 2, 3, 4], [1, 2, 3], [2, 5, 6, 7, 8, 9]])
     y = [0, 0, 1]
+
+Classification
+--------------
+
+* :ref:`KNeighborsTimeSeriesClassifier <knn-clf>`
+* :ref:`TimeSeriesSVC <class-svc>`
+
+Examples
+~~~~~~~~
+
+.. code-block:: python
+
+    from tslearn.neighbors import KNeighborsTimeSeriesClassifier
+    knn = KNeighborsTimeSeriesClassifier(n_neighbors=2)
+    knn.fit(X, y)
+
+.. code-block:: python
+
+    from tslearn.svm import TimeSeriesSVC
+    clf = TimeSeriesSVC(C=1.0, kernel="gak")
+    clf.fit(X, y)
+
+Regression
+----------
+
+* :ref:`TimeSeriesSVR <class-svr>`
+
+Examples
+~~~~~~~~
+
+.. code-block:: python
+
+    from tslearn.svm import TimeSeriesSVR
+    clf = TimeSeriesSVR(C=1.0, kernel="gak")
+    y_reg = [1.3, 5.2, -12.2]
+    clf.fit(X, y_reg)
 
 Clustering
 ----------
@@ -61,3 +99,22 @@ Examples
     from tslearn.utils import ts_zeros
     initial_barycenter = ts_zeros(sz=5)
     bar = softdtw_barycenter(X, init=initial_barycenter)
+
+Model selection
+---------------
+
+Also, model selection tools offered by `sklearn` can be used on variable-length
+data, in a standard way, such as:
+
+.. code-block:: python
+
+    from sklearn.model_selection import KFold, GridSearchCV
+    from tslearn.neighbors import KNeighborsTimeSeriesClassifier
+
+    knn = KNeighborsTimeSeriesClassifier(metric="dtw")
+    p_grid = {"n_neighbors": [1, 5]}
+
+    cv = KFold(n_splits=2, shuffle=True, random_state=0)
+    clf = GridSearchCV(estimator=knn, param_grid=p_grid, cv=cv)
+    clf.fit(X, y)
+

--- a/tslearn/docs/variablelength.rst
+++ b/tslearn/docs/variablelength.rst
@@ -44,8 +44,8 @@ Examples
 Barycenter computation
 ----------------------
 
-* :ref:`DTWBarycenterAveraging <class-dba>`
-* :ref:`SoftDTWBarycenter <class-softdtw>`
+* :ref:`dtw_barycenter_averaging <fun-dba>`
+* :ref:`softdtw_barycenter <fun-softdtwbar>`
 
 Examples
 ~~~~~~~~

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -316,3 +316,6 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
             X_ = to_sklearn_dataset(X)
             X_ = check_dims(X_, self._X_fit, extend=False)
         return super(KNeighborsTimeSeriesClassifier, self).predict_proba(X_)
+
+    def _get_tags(self):
+        return {'allow_nan': True}

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -335,4 +335,4 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
                          self).predict_proba(X_)
 
     def _get_tags(self):
-        return {'allow_nan': True, 'no_validation': True}
+        return {'allow_nan': True, 'allow_variable_length': True}

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -321,7 +321,8 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
                 X_ = cdist_dtw(X, self._ts_fit, **metric_params)
             elif self._ts_metric == "softdtw":
                 X_ = cdist_soft_dtw(X, self._ts_fit, **metric_params)
-            pred = super(KNeighborsTimeSeriesClassifier, self).predict(X_)
+            pred = super(KNeighborsTimeSeriesClassifier,
+                         self).predict_proba(X_)
             self.metric = self._ts_metric
             return pred
         else:
@@ -330,7 +331,8 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
             X = to_time_series_dataset(X)
             X_ = to_sklearn_dataset(X)
             X_ = check_dims(X_, self._X_fit, extend=False)
-            return super(KNeighborsTimeSeriesClassifier, self).predict_proba(X_)
+            return super(KNeighborsTimeSeriesClassifier,
+                         self).predict_proba(X_)
 
     def _get_tags(self):
         return {'allow_nan': True, 'no_validation': True}

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -306,7 +306,10 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         X : array-like, shape (n_ts, sz, d)
             Test samples.
         """
-        if self.metric == "precomputed" and hasattr(self, '_ts_metric'):
+        if self.metric in self.variable_length_metrics:
+            self._ts_metric = self.metric
+            self.metric = "precomputed"
+
             if self.metric_params is None:
                 metric_params = {}
             else:

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -232,9 +232,6 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
                                       algorithm='brute')
         self.metric = metric
         self.metric_params = metric_params
-        if metric in self.variable_length_metrics:
-            self.metric = "precomputed"
-            self._ts_metric = metric
 
     def fit(self, X, y):
         """Fit the model using X as training data and y as target values
@@ -246,6 +243,10 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         y : array-like, shape (n_ts, )
             Target values.
         """
+        if self.metric in self.variable_length_metrics:
+            self._ts_metric = self.metric
+            self.metric = "precomputed"
+
         X = check_array(X,
                         allow_nd=True,
                         force_all_finite=(self.metric != "precomputed"))

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -319,15 +319,18 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
             X = to_time_series_dataset(X)
             if self._ts_metric == "dtw":
                 X_ = cdist_dtw(X, self._ts_fit, **metric_params)
-            elif self._ts_metric == "soft-dtw":
+            elif self._ts_metric == "softdtw":
                 X_ = cdist_soft_dtw(X, self._ts_fit, **metric_params)
+            pred = super(KNeighborsTimeSeriesClassifier, self).predict(X_)
+            self.metric = self._ts_metric
+            return pred
         else:
             check_is_fitted(self, '_X_fit')
             X = check_array(X, allow_nd=True)
             X = to_time_series_dataset(X)
             X_ = to_sklearn_dataset(X)
             X_ = check_dims(X_, self._X_fit, extend=False)
-        return super(KNeighborsTimeSeriesClassifier, self).predict_proba(X_)
+            return super(KNeighborsTimeSeriesClassifier, self).predict_proba(X_)
 
     def _get_tags(self):
         return {'allow_nan': True, 'no_validation': True}

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -11,11 +11,11 @@ from sklearn.utils import check_array
 from sklearn.utils.validation import check_is_fitted
 from scipy.spatial.distance import cdist as scipy_cdist
 
-from tslearn.metrics import cdist_dtw
+from tslearn.metrics import cdist_dtw, cdist_soft_dtw
 from tslearn.utils import (to_time_series_dataset, to_sklearn_dataset,
                            check_dims)
 
-neighbors.VALID_METRICS['brute'].append('dtw')
+neighbors.VALID_METRICS['brute'].extend(['dtw', 'softdtw'])
 
 
 class KNeighborsTimeSeriesMixin(KNeighborsMixin):
@@ -50,27 +50,38 @@ class KNeighborsTimeSeriesMixin(KNeighborsMixin):
         if n_neighbors is None:
             n_neighbors = self.n_neighbors
         if X is None:
-            X = self._fit_X
+            X = self._X_fit
             self_neighbors = True
-        if self.metric == "dtw" or self.metric == cdist_dtw:
-            cdist_fun = cdist_dtw
-        elif self.metric in ["euclidean", "sqeuclidean", "cityblock"]:
-            def cdist_fun(X, Xp):
-                return scipy_cdist(X.reshape((X.shape[0], -1)),
-                                   Xp.reshape((Xp.shape[0], -1)),
-                                   metric=self.metric)
+        if self.metric == "precomputed":
+            full_dist_matrix = X
         else:
-            raise ValueError("Unrecognized time series metric string: %s "
-                             "(should be one of 'dtw', 'euclidean', "
-                             "'sqeuclidean' or 'cityblock')" % self.metric)
+            if self.metric == "dtw" or self.metric == cdist_dtw:
+                cdist_fun = cdist_dtw
+            elif self.metric == "softdtw" or self.metric == cdist_soft_dtw:
+                cdist_fun = cdist_soft_dtw
+            elif self.metric in ["euclidean", "sqeuclidean", "cityblock"]:
+                def cdist_fun(X, Xp):
+                    return scipy_cdist(X.reshape((X.shape[0], -1)),
+                                       Xp.reshape((Xp.shape[0], -1)),
+                                       metric=self.metric)
+            else:
+                raise ValueError("Unrecognized time series metric string: %s "
+                                 "(should be one of 'dtw', 'softdtw', "
+                                 "'euclidean', 'sqeuclidean' "
+                                 "or 'cityblock')" % self.metric)
 
-        if X.ndim == 2:  # sklearn-format case
-            X = X.reshape((X.shape[0], -1, self._d))
-            fit_X = self._fit_X.reshape((self._fit_X.shape[0], -1, self._d))
-        else:
-            fit_X = self._fit_X
+            if X.ndim == 2:  # sklearn-format case
+                X = X.reshape((X.shape[0], -1, self._d))
+                fit_X = self._X_fit.reshape((self._X_fit.shape[0],
+                                             -1,
+                                             self._d))
+            else:
+                fit_X = self._X_fit
 
-        full_dist_matrix = cdist_fun(X, fit_X)
+            if self.metric_params is not None:
+                full_dist_matrix = cdist_fun(X, fit_X, **self.metric_params)
+            else:
+                full_dist_matrix = cdist_fun(X, fit_X)
         ind = numpy.argsort(full_dist_matrix, axis=1)
 
         if self_neighbors:
@@ -96,7 +107,8 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors):
     ----------
     n_neighbors : int (default: 5)
         Number of nearest neighbors to be considered for the decision.
-    metric : {'dtw', 'euclidean', 'sqeuclidean', 'cityblock'} (default: 'dtw')
+    metric : {'dtw', 'softdtw', 'euclidean', 'sqeuclidean', 'cityblock'}
+    (default: 'dtw')
         Metric to be used at the core of the nearest neighbor procedure.
         DTW is described in more details in :mod:`tslearn.metrics`.
         Other metrics are described in `scipy.spatial.distance doc
@@ -139,7 +151,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors):
             Training data.
         """
         X = check_array(X, allow_nd=True)
-        self._fit_X = to_time_series_dataset(X)
+        self._X_fit = to_time_series_dataset(X)
         return self
 
     def kneighbors(self, X=None, n_neighbors=None, return_distance=True):
@@ -207,6 +219,8 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
     ...         y=[0, 0, 1]).predict([[1, 2.2, 3.5]])
     array([0])
     """
+    variable_length_metrics = ["dtw", "softdtw"]
+
     def __init__(self,
                  n_neighbors=5,
                  weights='uniform',
@@ -218,6 +232,9 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
                                       algorithm='brute')
         self.metric = metric
         self.metric_params = metric_params
+        if metric in self.variable_length_metrics:
+            self.metric = "precomputed"
+            self._ts_metric = metric
 
     def fit(self, X, y):
         """Fit the model using X as training data and y as target values
@@ -229,10 +246,18 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         y : array-like, shape (n_ts, )
             Target values.
         """
-        X = check_array(X, allow_nd=True)
+        X = check_array(X,
+                        allow_nd=True,
+                        force_all_finite=(self.metric != "precomputed"))
         X = to_time_series_dataset(X)
         X = check_dims(X, X_fit=None)
-        self._X_fit, self._d = to_sklearn_dataset(X, return_dim=True)
+        if self.metric == "precomputed" and hasattr(self, '_ts_metric'):
+            self._ts_fit = X
+            self._d = X.shape[2]
+            self._X_fit = numpy.zeros((self._ts_fit.shape[0],
+                                       self._ts_fit.shape[0]))
+        else:
+            self._X_fit, self._d = to_sklearn_dataset(X, return_dim=True)
         return super(KNeighborsTimeSeriesClassifier, self).fit(self._X_fit, y)
 
     def predict(self, X):
@@ -243,11 +268,24 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         X : array-like, shape (n_ts, sz, d)
             Test samples.
         """
-        check_is_fitted(self, '_X_fit')
-        X = check_array(X, allow_nd=True)
-        X = to_time_series_dataset(X)
-        X_ = to_sklearn_dataset(X)
-        X_ = check_dims(X_, self._X_fit, extend=False)
+        if self.metric == "precomputed" and hasattr(self, '_ts_metric'):
+            if self.metric_params is None:
+                metric_params = {}
+            else:
+                metric_params = self.metric_params
+            check_is_fitted(self, '_ts_fit')
+            X = check_array(X, allow_nd=True, force_all_finite=False)
+            X = to_time_series_dataset(X)
+            if self._ts_metric == "dtw":
+                X_ = cdist_dtw(X, self._ts_fit, **metric_params)
+            elif self._ts_metric == "softdtw":
+                X_ = cdist_soft_dtw(X, self._ts_fit, **metric_params)
+        else:
+            check_is_fitted(self, '_X_fit')
+            X = check_array(X, allow_nd=True)
+            X = to_time_series_dataset(X)
+            X_ = to_sklearn_dataset(X)
+            X_ = check_dims(X_, self._X_fit, extend=False)
         return super(KNeighborsTimeSeriesClassifier, self).predict(X_)
 
     def predict_proba(self, X):
@@ -258,9 +296,22 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         X : array-like, shape (n_ts, sz, d)
             Test samples.
         """
-        check_is_fitted(self, '_X_fit')
-        X = check_array(X, allow_nd=True)
-        X = to_time_series_dataset(X)
-        X_ = to_sklearn_dataset(X)
-        X_ = check_dims(X_, self._X_fit, extend=False)
+        if self.metric == "precomputed" and hasattr(self, '_ts_metric'):
+            if self.metric_params is None:
+                metric_params = {}
+            else:
+                metric_params = self.metric_params
+            check_is_fitted(self, '_ts_fit')
+            X = check_array(X, allow_nd=True, force_all_finite=False)
+            X = to_time_series_dataset(X)
+            if self._ts_metric == "dtw":
+                X_ = cdist_dtw(X, self._ts_fit, **metric_params)
+            elif self._ts_metric == "soft-dtw":
+                X_ = cdist_soft_dtw(X, self._ts_fit, **metric_params)
+        else:
+            check_is_fitted(self, '_X_fit')
+            X = check_array(X, allow_nd=True)
+            X = to_time_series_dataset(X)
+            X_ = to_sklearn_dataset(X)
+            X_ = check_dims(X_, self._X_fit, extend=False)
         return super(KNeighborsTimeSeriesClassifier, self).predict_proba(X_)

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -330,4 +330,4 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         return super(KNeighborsTimeSeriesClassifier, self).predict_proba(X_)
 
     def _get_tags(self):
-        return {'allow_nan': True}
+        return {'allow_nan': True, 'no_validation': True}

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -205,9 +205,8 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         - [callable] : a user-defined function which accepts an array of
           distances, and returns an array of the same
           shape containing the weights.
-    metric : one of the metrics allowed for class
-    :class:`.KNeighborsTimeSeries`
-        (default: 'dtw')
+    metric : one of the metrics allowed for :class:`.KNeighborsTimeSeries`
+    class (default: 'dtw')
         Metric to be used at the core of the nearest neighbor procedure
     metric_params : dict or None (default: None)
         Dictionnary of metric parameters.

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -73,16 +73,16 @@ class TimeSeriesScalerMinMax(TransformerMixin):
     min : float (default: 0.)
         Minimum value for output time series.
 
-        .. deprecated:: 0.1
-            min is deprecated in version 0.1 and will be
-            removed in 0.2.
+        .. deprecated:: 0.2
+            min is deprecated in version 0.2 and will be
+            removed in 0.4.
 
     max : float (default: 1.)
         Maximum value for output time series.
 
-        .. deprecated:: 0.1
-            min is deprecated in version 0.1 and will be
-            removed in 0.2.
+        .. deprecated:: 0.2
+            min is deprecated in version 0.2 and will be
+            removed in 0.4.
 
     Note
     ----
@@ -90,8 +90,7 @@ class TimeSeriesScalerMinMax(TransformerMixin):
 
     Example
     -------
-    >>> TimeSeriesScalerMinMax(min=1.,
-    ...                        max=2.).fit_transform([[0, 3, 6]])
+    >>> TimeSeriesScalerMinMax(value_range=(1., 2.)).fit_transform([[0, 3, 6]])
     array([[[1. ],
             [1.5],
             [2. ]]])
@@ -133,16 +132,16 @@ class TimeSeriesScalerMinMax(TransformerMixin):
         """
         if self.min_ is not None:
             warnings.warn(
-                "'min' is deprecated in version 0.1 and will be "
-                "removed in 0.2. Don't set `min` to remove this "
+                "'min' is deprecated in version 0.2 and will be "
+                "removed in 0.4. Don't set `min` to remove this "
                 "warning.",
                 DeprecationWarning, stacklevel=2)
             self.value_range = (self.min_, self.value_range[1])
 
         if self.max_ is not None:
             warnings.warn(
-                "'max' is deprecated in version 0.1 and will be "
-                "removed in 0.2. Don't set `max` to remove this "
+                "'max' is deprecated in version 0.2 and will be "
+                "removed in 0.4. Don't set `max` to remove this "
                 "warning.",
                 DeprecationWarning, stacklevel=2)
             self.value_range = (self.value_range[0], self.max_)

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -1,6 +1,6 @@
 """
-The :mod:`tslearn.svm` module contains Support Vector Classifier (SVC) and Support Vector Regressor (SVR) models
-for time series.
+The :mod:`tslearn.svm` module contains Support Vector Classifier (SVC) and
+Support Vector Regressor (SVR) models for time series.
 """
 
 from sklearn.svm import SVC, SVR
@@ -75,32 +75,43 @@ class TimeSeriesSVC(TimeSeriesSVMMixin, BaseEstimator, ClassifierMixin):
     ----------
     C : float, optional (default=1.0)
         Penalty parameter C of the error term.
+
     kernel : string, optional (default='gak')
          Specifies the kernel type to be used in the algorithm.
          It must be one of 'gak' or a kernel accepted by ``sklearn.svm.SVC``.
          If none is given, 'gak' will be used. If a callable is given it is
          used to pre-compute the kernel matrix from data matrices; that matrix
          should be an array of shape ``(n_samples, n_samples)``.
+
     degree : int, optional (default=3)
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
+
     gamma : float, optional (default='auto')
         Kernel coefficient for 'gak', 'rbf', 'poly' and 'sigmoid'.
         If gamma is 'auto' then:
-        - for 'gak' kernel, it is computed based on a sampling of the training set (cf `tslearn.metrics.gamma_soft_dtw`)
+
+        - for 'gak' kernel, it is computed based on a sampling of the training
+          set (cf :ref:`tslearn.metrics.gamma_soft_dtw <fun-gammasoftdtw>`)
         - for other kernels (eg. 'rbf'), 1/n_features will be used.
+
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
+
     shrinking : boolean, optional (default=True)
         Whether to use the shrinking heuristic.
+
     probability : boolean, optional (default=True)
         Whether to enable probability estimates. This must be enabled prior
         to calling `fit`, and will slow down that method.
+
     tol : float, optional (default=1e-3)
         Tolerance for stopping criterion.
+
     cache_size : float, optional (default=200.0)
         Specify the size of the kernel cache (in MB).
+
     class_weight : {dict, 'balanced'}, optional
         Set the parameter C of class i to class_weight[i]*C for
         SVC. If not given, all classes are supposed to have
@@ -108,17 +119,21 @@ class TimeSeriesSVC(TimeSeriesSVMMixin, BaseEstimator, ClassifierMixin):
         The "balanced" mode uses the values of y to automatically adjust
         weights inversely proportional to class frequencies in the input data
         as ``n_samples / (n_classes * np.bincount(y))``
+
     verbose : bool, default: False
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in libsvm that, if enabled, may not work
         properly in a multithreaded context.
+
     max_iter : int, optional (default=-1)
         Hard limit on iterations within solver, or -1 for no limit.
+
     decision_function_shape : 'ovo', 'ovr', default='ovr'
         Whether to return a one-vs-rest ('ovr') decision function of shape
         (n_samples, n_classes) as all other classifiers, or the original
         one-vs-one ('ovo') decision function of libsvm which has shape
         (n_samples, n_classes * (n_classes - 1) / 2).
+
     random_state : int, RandomState instance or None, optional (default=None)
         The seed of the pseudo random number generator to use when shuffling
         the data.  If int, random_state is the seed used by the random number
@@ -130,21 +145,26 @@ class TimeSeriesSVC(TimeSeriesSVMMixin, BaseEstimator, ClassifierMixin):
     ----------
     support_ : array-like, shape = [n_SV]
         Indices of support vectors.
+
     n_support_ : array-like, dtype=int32, shape = [n_class]
         Number of support vectors for each class.
+
     dual_coef_ : array, shape = [n_class-1, n_SV]
         Coefficients of the support vector in the decision function.
         For multiclass, coefficient for all 1-vs-1 classifiers.
         The layout of the coefficients in the multiclass case is somewhat
         non-trivial. See the section about multi-class classification in the
         SVM section of the User Guide of ``sklearn`` for details.
+
     coef_ : array, shape = [n_class-1, n_features]
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
         `coef_` is a readonly property derived from `dual_coef_` and
         `support_vectors_`.
+
     intercept_ : array, shape = [n_class * (n_class-1) / 2]
         Constants in decision function.
+
     svm_estimator_ : sklearn.svm.SVC
         The underlying support vector machine
 
@@ -266,38 +286,50 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, BaseEstimator, RegressorMixin):
     ----------
     C : float, optional (default=1.0)
         Penalty parameter C of the error term.
+
     kernel : string, optional (default='gak')
          Specifies the kernel type to be used in the algorithm.
          It must be one of 'gak' or a kernel accepted by ``sklearn.svm.SVC``.
          If none is given, 'gak' will be used. If a callable is given it is
          used to pre-compute the kernel matrix from data matrices; that matrix
          should be an array of shape ``(n_samples, n_samples)``.
+
     degree : int, optional (default=3)
         Degree of the polynomial kernel function ('poly').
         Ignored by all other kernels.
+
     gamma : float, optional (default='auto')
         Kernel coefficient for 'gak', 'rbf', 'poly' and 'sigmoid'.
         If gamma is 'auto' then:
-        - for 'gak' kernel, it is computed based on a sampling of the training set (cf `tslearn.metrics.gamma_soft_dtw`)
+
+        - for 'gak' kernel, it is computed based on a sampling of the training
+          set (cf :ref:`tslearn.metrics.gamma_soft_dtw <fun-gammasoftdtw>`)
         - for other kernels (eg. 'rbf'), 1/n_features will be used.
+
     coef0 : float, optional (default=0.0)
         Independent term in kernel function.
         It is only significant in 'poly' and 'sigmoid'.
+
     tol : float, optional (default=1e-3)
         Tolerance for stopping criterion.
+
     epsilon : float, optional (default=0.1)
          Epsilon in the epsilon-SVR model. It specifies the epsilon-tube
          within which no penalty is associated in the training loss function
          with points predicted within a distance epsilon from the actual
          value.
+
     shrinking : boolean, optional (default=True)
         Whether to use the shrinking heuristic.
+
     cache_size :  float, optional (default=200.0)
         Specify the size of the kernel cache (in MB).
+
     verbose : bool, default: False
         Enable verbose output. Note that this setting takes advantage of a
         per-process runtime setting in libsvm that, if enabled, may not work
         properly in a multithreaded context.
+
     max_iter : int, optional (default=-1)
         Hard limit on iterations within solver, or -1 for no limit.
 
@@ -305,17 +337,22 @@ class TimeSeriesSVR(TimeSeriesSVMMixin, BaseEstimator, RegressorMixin):
     ----------
     support_ : array-like, shape = [n_SV]
         Indices of support vectors.
+
     dual_coef_ : array, shape = [1, n_SV]
         Coefficients of the support vector in the decision function.
+
     coef_ : array, shape = [1, n_features]
         Weights assigned to the features (coefficients in the primal
         problem). This is only available in the case of a linear kernel.
         `coef_` is readonly property derived from `dual_coef_` and
         `support_vectors_`.
+
     intercept_ : array, shape = [1]
         Constants in decision function.
+
     sample_weight : array-like, shape = [n_samples]
         Individual weights for each sample
+
     svm_estimator_ : sklearn.svm.SVR
         The underlying support vector machine
 

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -221,8 +221,11 @@ class TimeSeriesSVC(BaseEstimator, ClassifierMixin):
         self.svm_estimator_ = SVC(
             C=self.C, kernel=estimator_kernel, degree=self.degree,
             gamma=self.gamma, coef0=self.coef0, shrinking=self.shrinking,
-            tol=self.tol, cache_size=self.cache_size,
-            verbose=self.verbose, max_iter=self.max_iter
+            probability=self.probability, tol=self.tol,
+            cache_size=self.cache_size, class_weight=self.class_weight,
+            verbose=self.verbose, max_iter=self.max_iter,
+            decision_function_shape=self.decision_function_shape,
+            random_state=self.random_state
         )
         self.svm_estimator_.fit(sklearn_X, y, sample_weight=sample_weight)
 

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -218,7 +218,7 @@ class TimeSeriesSVC(BaseEstimator, ClassifierMixin):
             estimator_kernel = self.kernel
             sklearn_X = _prepare_ts_datasets_sklearn(X)
 
-        self.svm_estimator_ = SVR(
+        self.svm_estimator_ = SVC(
             C=self.C, kernel=estimator_kernel, degree=self.degree,
             gamma=self.gamma, coef0=self.coef0, shrinking=self.shrinking,
             tol=self.tol, cache_size=self.cache_size,

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -34,6 +34,7 @@ _DEFAULT_TAGS = {
     'no_validation': False,
     'multioutput': False,
     "allow_nan": False,
+    'allow_variable_length': False,
     'stateless': False,
     'multilabel': False,
     '_skip_test': False,
@@ -298,7 +299,7 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False):
                "features in {} is different from the number of features in "
                "fit.")
 
-        if not tags["no_validation"]:
+        if not tags["no_validation"] and not tags["allow_variable_length"]:
             if bool(getattr(classifier, "_pairwise", False)):
                 with assert_raises(ValueError,
                                    msg=msg_pairwise.format(name, "predict")):
@@ -345,7 +346,7 @@ def check_classifiers_train(name, classifier_orig, readonly_memmap=False):
             # check that probas for all classes sum to one
             assert_array_almost_equal(np.sum(y_prob, axis=1),
                                       np.ones(n_samples))
-            if not tags["no_validation"]:
+            if not tags["no_validation"] and not tags["allow_variable_length"]:
                 # raises error on malformed input for predict_proba
                 if bool(getattr(classifier_orig, "_pairwise", False)):
                     with assert_raises(ValueError, msg=msg_pairwise.format(

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -14,6 +14,7 @@ from sklearn.base import (BaseEstimator, ClassifierMixin, ClusterMixin,
 
 from sklearn.utils.testing import *
 from sklearn_patches import *
+from sklearn_patches import _safe_tags, _DEFAULT_TAGS
 
 import warnings
 
@@ -35,10 +36,6 @@ checks.check_regressors_int = check_regressors_int_patched
 checks.check_classifiers_regression_target = check_classifiers_cont_target
 checks.check_pipeline_consistency = check_pipeline_consistency
 
-
-if hasattr(checks, 'ALLOW_NAN'):
-    checks.ALLOW_NAN.extend(['TimeSeriesKMeans',
-                             'KNeighborsTimeSeriesClassifier'])
 
 
 def _get_all_classes():
@@ -162,5 +159,8 @@ def check_estimator(Estimator):
 def test_all_estimators():
     estimators = get_estimators('all')
     for estimator in estimators:
+        if hasattr(checks, 'ALLOW_NAN') \
+                and _safe_tags(estimator[1](), "allow_nan"):
+            checks.ALLOW_NAN.append(estimator[0])
         check_estimator(estimator[1])
         print(estimator[0])

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -37,7 +37,8 @@ checks.check_pipeline_consistency = check_pipeline_consistency
 
 
 if hasattr(checks, 'ALLOW_NAN'):
-    checks.ALLOW_NAN.append('TimeSeriesKMeans')
+    checks.ALLOW_NAN.extend(['TimeSeriesKMeans',
+                             'KNeighborsTimeSeriesClassifier'])
 
 
 def _get_all_classes():

--- a/tslearn/tests/test_variablelength.py
+++ b/tslearn/tests/test_variablelength.py
@@ -1,0 +1,16 @@
+from numpy.testing import assert_allclose
+
+from tslearn.neighbors import KNeighborsTimeSeriesClassifier
+from tslearn.utils import to_time_series_dataset
+
+__author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
+
+
+
+def test_variable_length_knn():
+    X = to_time_series_dataset([[1, 2, 3, 4], [1, 2, 3], [2, 5, 6, 7, 8, 9]])
+    y = [0, 0, 1]
+
+    clf = KNeighborsTimeSeriesClassifier(metric="dtw", n_neighbors=1)
+    clf.fit(X, y)
+    assert_allclose(clf.predict(X), [0, 0, 1])

--- a/tslearn/tests/test_variablelength.py
+++ b/tslearn/tests/test_variablelength.py
@@ -1,16 +1,85 @@
-from numpy.testing import assert_allclose
+import numpy as np
+from numpy.testing import assert_allclose, assert_array_less
+from sklearn.model_selection import cross_val_score, KFold
 
 from tslearn.neighbors import KNeighborsTimeSeriesClassifier
+from tslearn.svm import TimeSeriesSVC, TimeSeriesSVR
+from tslearn.clustering import GlobalAlignmentKernelKMeans, TimeSeriesKMeans
 from tslearn.utils import to_time_series_dataset
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 
-
 def test_variable_length_knn():
-    X = to_time_series_dataset([[1, 2, 3, 4], [1, 2, 3], [2, 5, 6, 7, 8, 9]])
-    y = [0, 0, 1]
-
+    X = to_time_series_dataset([[1, 2, 3, 4],
+                                [1, 2, 3],
+                                [2, 5, 6, 7, 8, 9],
+                                [3, 5, 6, 7, 8]])
+    y = [0, 0, 1, 1]
     clf = KNeighborsTimeSeriesClassifier(metric="dtw", n_neighbors=1)
     clf.fit(X, y)
-    assert_allclose(clf.predict(X), [0, 0, 1])
+    assert_allclose(clf.predict(X), [0, 0, 1, 1])
+
+    clf = KNeighborsTimeSeriesClassifier(metric="softdtw", n_neighbors=1)
+    clf.fit(X, y)
+    assert_allclose(clf.predict(X), [0, 0, 1, 1])
+
+def test_variable_length_svm():
+    X = to_time_series_dataset([[1, 2, 3, 4],
+                                [1, 2, 3],
+                                [2, 5, 6, 7, 8, 9],
+                                [3, 5, 6, 7, 8]])
+    y = [0, 0, 1, 1]
+    rng = np.random.RandomState(0)
+    clf = TimeSeriesSVC(kernel="gak", random_state=rng)
+    clf.fit(X, y)
+    assert_allclose(clf.predict(X), [0, 0, 1, 1])
+
+    y_reg = [-1., -1.3, 3.2, 4.1]
+    clf = TimeSeriesSVR(kernel="gak")
+    clf.fit(X, y_reg)
+    assert_array_less(clf.predict(X[:2]), 0.)
+    assert_array_less(-clf.predict(X[2:]), 0.)
+
+def test_variable_length_clustering():
+    # TODO: here we just check that they can accept variable-length TS, not
+    # that they do clever things
+    X = to_time_series_dataset([[1, 2, 3, 4],
+                                [1, 2, 3],
+                                [2, 5, 6, 7, 8, 9],
+                                [3, 5, 6, 7, 8]])
+    rng = np.random.RandomState(0)
+
+    clf = GlobalAlignmentKernelKMeans(n_clusters=2, random_state=rng)
+    clf.fit(X)
+
+    clf = TimeSeriesKMeans(n_clusters=2, metric="dtw", random_state=rng)
+    clf.fit(X)
+
+    clf = TimeSeriesKMeans(n_clusters=2, metric="softdtw", random_state=rng)
+    clf.fit(X)
+
+def test_variable_cross_val():
+    # TODO: here we just check that they can accept variable-length TS, not
+    # that they do clever things
+    X = to_time_series_dataset([[1, 2, 3, 4],
+                                [1, 2, 3],
+                                [1, 2, 3, 4],
+                                [1, 2, 3],
+                                [2, 5, 6, 7, 8, 9],
+                                [3, 5, 6, 7, 8],
+                                [2, 5, 6, 7, 8, 9],
+                                [3, 5, 6, 7, 8]])
+    y = [0, 0, 0, 0, 1, 1, 1, 1]
+    rng = np.random.RandomState(0)
+
+    cv = KFold(n_splits=2, shuffle=True)
+    for estimator in [
+        TimeSeriesSVC(kernel="gak", random_state=rng),
+        TimeSeriesSVR(kernel="gak"),
+        KNeighborsTimeSeriesClassifier(metric="dtw", n_neighbors=1),
+        KNeighborsTimeSeriesClassifier(metric="softdtw", n_neighbors=1)
+    ]:
+        # TODO: cannot test for clustering methods since they don't have a
+        # score method yet
+        cross_val_score(estimator, X=X, y=y, cv=cv)


### PR DESCRIPTION
This is an attempt to make it possible to use estimators with metrics like DTW on variable-length time series.

The first attempt here is to make DTW/soft-DTW usable for kNN estimators on variable-length time series.

The test I ran is:

```python
from tslearn.neighbors import KNeighborsTimeSeriesClassifier
from tslearn.utils import to_time_series_dataset


X = to_time_series_dataset([[1, 2, 3, 4], [1, 2, 3], [2, 5, 6, 7, 8, 9]])
y = [0, 0, 1]

clf = KNeighborsTimeSeriesClassifier(metric="dtw",
                                     n_neighbors=1,
                                     metric_params={"global_constraint": "sakoe_chiba"})
clf.fit(X, y)
print("---", clf._ts_fit)
print(clf.predict(X))
```

First, we have to think about whether the hack I introduced is a good way to reach our goal and second, once we have chosen a way to proceed, we will have to:
- do the same for other estimators (all those that accept dtw, soft-dtw, gak as metrics, ideally)
- find a way to hack sklearn k-fold variants, since there are some checks for all-finite entries in the datasets there which fail for variable-length time series, if I remember correctly

@GillesVandewiele since you recently worked on making the estimators sklearn-compatible, could you review this PR?