### PR TITLE
Fix documentation for dtw_path

### DIFF
--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -209,7 +209,7 @@ def dtw_path(s1, s2, global_constraint=None,
         ``global_constraint="sakoe_chiba"``.
     itakura_max_slope : float (default: 2.)
         Maximum slope for the Itakura parallelogram constraint. Used only if
-        ``global_constraint="itakura_parallelogram"``.
+        ``global_constraint="itakura"``.
 
     Returns
     -------


### PR DESCRIPTION
The values allowed for the parameter `global_constraint` were probably changed somewhere down the road, and the parameter value in `itakura_max_slope` was not updated accordingly.