### PR TITLE
Replace implicit imports with explicit imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,12 @@ script:
 - python -c "import keras.backend";
   sed -i -e 's/"backend":[[:space:]]*"[^"]*/"backend":\ "'$KERAS_BACKEND'/g' ~/.keras/keras.json;
   echo -e "Running tests with the following config:\n$(cat ~/.keras/keras.json)";
-- if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then
+- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then
   python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
-  if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then codeclimate-test-reporter; fi
-  else travis_wait 40 python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE; fi
+  else python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE;
+
+after_success:
+- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then codeclimate-test-reporter
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ script:
   sed -i -e 's/"backend":[[:space:]]*"[^"]*/"backend":\ "'$KERAS_BACKEND'/g' ~/.keras/keras.json;
   echo -e "Running tests with the following config:\n$(cat ~/.keras/keras.json)";
 - if [ "$NUMBA_DISABLE_JIT" == 1 ];
-  then python -m pytest -v --pyargs tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
-  else python -m pytest -v --pyargs tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE;
+  then python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
+  else python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE;
   fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,8 @@ script:
   sed -i -e 's/"backend":[[:space:]]*"[^"]*/"backend":\ "'$KERAS_BACKEND'/g' ~/.keras/keras.json;
   echo -e "Running tests with the following config:\n$(cat ~/.keras/keras.json)";
 - if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then
-  python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py --ignore tslearn/tests/test_estimators.py $KERAS_IGNORE --cov=tslearn;
+  python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
   if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then codeclimate-test-reporter; fi
   else travis_wait 40 python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE; fi
 notifications:
   email: false
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,13 @@ script:
 - python -c "import keras.backend";
   sed -i -e 's/"backend":[[:space:]]*"[^"]*/"backend":\ "'$KERAS_BACKEND'/g' ~/.keras/keras.json;
   echo -e "Running tests with the following config:\n$(cat ~/.keras/keras.json)";
-- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then
-  python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
+- if [ "$NUMBA_DISABLE_JIT" == 1 ];
+  then python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
   else python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE;
+  fi 
 
 after_success:
-- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then codeclimate-test-reporter
+- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then codeclimate-test-reporter fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ script:
   sed -i -e 's/"backend":[[:space:]]*"[^"]*/"backend":\ "'$KERAS_BACKEND'/g' ~/.keras/keras.json;
   echo -e "Running tests with the following config:\n$(cat ~/.keras/keras.json)";
 - if [ "$NUMBA_DISABLE_JIT" == 1 ];
-  then python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
-  else python -m pytest -v tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE;
-  fi 
+  then python -m pytest -v --pyargs tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE --cov=tslearn;
+  else python -m pytest -v --pyargs tslearn tslearn/tests/ --doctest-modules --ignore tslearn/docs --ignore tslearn/deprecated.py $KERAS_IGNORE;
+  fi
 
 after_success:
 - if [ "$NUMBA_DISABLE_JIT" == 1 ]; then codeclimate-test-reporter fi

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,5 @@ description-file = README.md
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
-    ignore::SkipTestWarning
+    ignore::sklearn.exceptions.SkipTestWarning
     ignore::UserWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,6 @@
 [metadata]
 description-file = README.md
+
+filterwarnings =
+    ignore::UserWarning
+    ignore::SkipTestWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 description-file = README.md
 
-[pytest]
+[tool:pytest]
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
 [metadata]
 description-file = README.md
-
-filterwarnings =
-    ignore::UserWarning
-    ignore::SkipTestWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,9 @@
 [metadata]
 description-file = README.md
+
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
+    ignore::SkipTestWarning
+    ignore::UserWarning

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     package_data={"tslearn": [".cached_datasets/Trace.npz"]},
     data_files=[("", ["LICENSE"])],
     install_requires=['numpy', 'scipy', 'scikit-learn', 'Cython', 'numba'],
-    extras_require=['pytest'],
+    extras_require={'tests': ['pytest']},
     ext_modules=cythonize("tslearn/*.pyx", include_path=[numpy.get_include()]),
     version=__version__,
     url="http://tslearn.readthedocs.io/",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     package_data={"tslearn": [".cached_datasets/Trace.npz"]},
     data_files=[("", ["LICENSE"])],
     install_requires=['numpy', 'scipy', 'scikit-learn', 'Cython', 'numba'],
+    extras_require=['pytest'],
     ext_modules=cythonize("tslearn/*.pyx", include_path=[numpy.get_include()]),
     version=__version__,
     url="http://tslearn.readthedocs.io/",

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -169,8 +169,8 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
     assert_array_equal(labels_sorted, np.arange(labels_sorted[0],
                                                 labels_sorted[-1] + 1))
 
-    # Labels are expected to start at 0 (no noise) or -1 (if noise)
-    assert labels_sorted[0] in [0, -1]
+    # Labels are expected to start at 0 (no noise) or 1 (if noise)
+    assert labels_sorted[0] in [0, 1]
 
     # Labels should be less than n_clusters - 1
     if hasattr(clusterer, 'n_clusters'):

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -1,4 +1,4 @@
-from tslearn.generators import random_walks, random_walk_blobs
+from tslearn.generators import random_walk_blobs
 from tslearn.preprocessing import TimeSeriesScalerMeanVariance
 
 import sklearn

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -130,7 +130,8 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
     X, y = _create_small_ts_dataset()
     X, y = shuffle(X, y, random_state=7)
     X = TimeSeriesScalerMeanVariance().fit_transform(X)
-    X_noise = np.concatenate([X, random_walks(n_ts=2, sz=10)])
+    rng = np.random.RandomState(42)
+    X_noise = X + (rng.randn(*X.shape()) / 5)
 
     n_samples, n_features, dim = X.shape
     # catch deprecation and neighbors warnings

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -163,15 +163,9 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
     # Add noise to X to test the possible values of the labels
     labels = clusterer.fit_predict(X_noise)
 
-    # There should be at least one sample in every cluster. Equivalently
-    # labels_ should contain all the consecutive values between its
-    # min and its max.
+    # There should be at least one sample in every original cluster
     labels_sorted = np.unique(labels)
-    assert_array_equal(labels_sorted, np.arange(labels_sorted[0],
-                                                labels_sorted[-1] + 1))
-
-    # Labels are expected to start at 0 (no noise) or 1 (if noise)
-    assert labels_sorted[0] in [0, 1]
+    assert_array_equal(labels_sorted, np.arange(0, 3))
 
     # Labels should be less than n_clusters - 1
     if hasattr(clusterer, 'n_clusters'):

--- a/tslearn/tests/sklearn_patches.py
+++ b/tslearn/tests/sklearn_patches.py
@@ -131,7 +131,7 @@ def check_clustering(name, clusterer_orig, readonly_memmap=False):
     X, y = shuffle(X, y, random_state=7)
     X = TimeSeriesScalerMeanVariance().fit_transform(X)
     rng = np.random.RandomState(42)
-    X_noise = X + (rng.randn(*X.shape()) / 5)
+    X_noise = X + (rng.randn(*X.shape) / 5)
 
     n_samples, n_features, dim = X.shape
     # catch deprecation and neighbors warnings

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -12,7 +12,7 @@ import sklearn
 from sklearn.base import (BaseEstimator, ClassifierMixin, ClusterMixin,
                           RegressorMixin, TransformerMixin)
 
-from sklearn.utils.testing import ignore_warnings, SkipTest
+from sklearn.utils.testing import SkipTest
 from sklearn.exceptions import SkipTestWarning
 from sklearn.utils.estimator_checks import (
     check_no_attributes_set_in_init,
@@ -169,7 +169,6 @@ def check_estimator(Estimator):
 
 
 @pytest.mark.parametrize('estimator', get_estimators('all'))
-@ignore_warnings()
 def test_all_estimators(estimator):
     """Test all the estimators in tslearn."""
     allow_nan = (hasattr(checks, 'ALLOW_NAN') and

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -32,6 +32,7 @@ from sklearn_patches import (check_clustering,
                              yield_all_checks)
 from sklearn_patches import _safe_tags
 import warnings
+import pytest
 
 
 # Patching some check functions to work on ts data instead of tabular data.
@@ -168,10 +169,11 @@ def check_estimator(Estimator):
 
 
 @ignore_warnings()
-def test_all_estimators():
-    estimators = get_estimators('all')
-    for estimator in estimators:
-        if hasattr(checks, 'ALLOW_NAN') \
-                and _safe_tags(estimator[1](), "allow_nan"):
-            checks.ALLOW_NAN.append(estimator[0])
-        check_estimator(estimator[1])
+@pytest.mark.parametrize('estimator', get_estimators('all'))
+def test_all_estimators(estimator):
+    """Test all the estimators in tslearn."""
+    allow_nan = (hasattr(checks, 'ALLOW_NAN') and
+                 _safe_tags(estimator[1](), "allow_nan"))
+    if allow_nan:
+        checks.ALLOW_NAN.append(estimator[0])
+    check_estimator(estimator[1])

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -12,13 +12,26 @@ import sklearn
 from sklearn.base import (BaseEstimator, ClassifierMixin, ClusterMixin,
                           RegressorMixin, TransformerMixin)
 
-from sklearn.utils.testing import *
-from sklearn_patches import *
-from sklearn_patches import _safe_tags, _DEFAULT_TAGS
-
+from sklearn.utils.testing import ignore_warnings, SkipTest
+from sklearn.exceptions import SkipTestWarning
+from sklearn.utils.estimator_checks import (
+    check_no_attributes_set_in_init,
+    check_parameters_default_constructible
+)
+from sklearn_patches import (check_clustering,
+                             check_non_transf_est_n_iter,
+                             check_fit_idempotent,
+                             check_classifiers_classes,
+                             check_classifiers_train,
+                             check_estimators_pickle,
+                             check_supervised_y_2d,
+                             check_regressor_data_not_an_array,
+                             check_regressors_int_patched,
+                             check_classifiers_cont_target,
+                             check_pipeline_consistency,
+                             yield_all_checks)
+from sklearn_patches import _safe_tags
 import warnings
-
-import logging
 
 
 # Patching some check functions to work on ts data instead of tabular data.
@@ -35,7 +48,6 @@ checks.check_regressor_data_not_an_array = check_regressor_data_not_an_array
 checks.check_regressors_int = check_regressors_int_patched
 checks.check_classifiers_regression_target = check_classifiers_cont_target
 checks.check_pipeline_consistency = check_pipeline_consistency
-
 
 
 def _get_all_classes():
@@ -64,7 +76,7 @@ def is_sklearn(x):
 
 def get_estimators(type_filter='all'):
     """Return a list of classes that inherit from `sklearn.BaseEstimator`.
-    This code is based on `sklearn,utils.testing.all_estimators`.
+    This code is based on `sklearn.utils.testing.all_estimators`.
 
     Parameters
     ----------

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -168,7 +168,6 @@ def check_estimator(Estimator):
             warnings.warn(str(exception), SkipTestWarning)
 
 
-@pytest.mark.filterwarnings('ignore')
 @pytest.mark.parametrize('estimator', get_estimators('all'))
 def test_all_estimators(estimator):
     """Test all the estimators in tslearn."""

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -168,6 +168,7 @@ def check_estimator(Estimator):
             warnings.warn(str(exception), SkipTestWarning)
 
 
+@pytest.mark.filterwarnings('ignore')
 @pytest.mark.parametrize('estimator', get_estimators('all'))
 def test_all_estimators(estimator):
     """Test all the estimators in tslearn."""

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -175,4 +175,3 @@ def test_all_estimators():
                 and _safe_tags(estimator[1](), "allow_nan"):
             checks.ALLOW_NAN.append(estimator[0])
         check_estimator(estimator[1])
-        print(estimator[0])

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -168,8 +168,8 @@ def check_estimator(Estimator):
             warnings.warn(str(exception), SkipTestWarning)
 
 
-@ignore_warnings()
 @pytest.mark.parametrize('estimator', get_estimators('all'))
+@ignore_warnings()
 def test_all_estimators(estimator):
     """Test all the estimators in tslearn."""
     allow_nan = (hasattr(checks, 'ALLOW_NAN') and


### PR DESCRIPTION
Fixes #134 

As title says, the implicit imports are replaced with explicit imports in `test_estimators.py`.
It was a bit hard to find some of them from scikit-learn. Let's see if it improves code coverage.