### PR TITLE
[MRG] Sakoe-Chiba band and Itakura parallelogram broken in DTW computations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,19 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on 
+The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to 
+and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Changelogs for this project are recorded in this file since v0.2.0.
 
 ## [v0.2.1]
+
+### Added
+
+* A `RuntimeWarning` is raised when an `'itakura'` constraint is set
+that is unfeasible given the provided shapes.
 
 ### Fixed
 
@@ -18,13 +23,13 @@ Changelogs for this project are recorded in this file since v0.2.0.
 
 ### Added
 
-* `tslearn` estimators are now automatically tested to match `sklearn` 
-requirements "as much as possible" (cf. `tslearn` needs in 
+* `tslearn` estimators are now automatically tested to match `sklearn`
+requirements "as much as possible" (cf. `tslearn` needs in
 terms of data format, _etc._)
 * `cdist_dtw` and `cdist_gak` now have a `n_jobs` parameter to parallelize
 distance computations using `joblib.Parallel`
-* `n_jobs` is also available as a prameter in 
-`silhouette_score`, `TimeSeriesKMeans`, `KNeighborsTimeSeries`, 
+* `n_jobs` is also available as a prameter in
+`silhouette_score`, `TimeSeriesKMeans`, `KNeighborsTimeSeries`,
 `KNeighborsTimeSeriesClassifier`, `TimeSeriesSVC`,
 `TimeSeriesSVR` and `GlobalAlignmentKernelKMeans`
 
@@ -35,12 +40,12 @@ distance computations using `joblib.Parallel`
 cross-validation tools, even (for those concerned) with variable-length data
 * doctests have been reduced to those necessary for documentation purposes, the
 other tests being moved to `tests/*.py`
-* The list of authors for the `tslearn` bibliographic reference has been 
+* The list of authors for the `tslearn` bibliographic reference has been
 updated to include Johann Faouzi and Gilles Van de Wiele
 * In `TimeSeriesScalerMinMax`, `min` and `max` parameters are now deprecated
 in favor of `value_range`. Will be removed in v0.4
-* In `TimeSeriesKMeans` and `silhouette_score`, `'gamma_sdtw'` is now 
-deprecated as a key for `metric_params` in favor of `gamma`. Will be removed 
+* In `TimeSeriesKMeans` and `silhouette_score`, `'gamma_sdtw'` is now
+deprecated as a key for `metric_params` in favor of `gamma`. Will be removed
 in v0.4
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 Changelogs for this project are recorded in this file since v0.2.0.
 
+## [v0.2.1]
+
+### Fixed
+
+* `'itakura'` and `'sakoe_chiba'` were swapped in `metrics.compute_mask`
+
 ## [v0.2.0]
 
 ### Added

--- a/tslearn/__init__.py
+++ b/tslearn/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __bibtex__ = r"""@misc{tslearn,
  title={tslearn: A machine learning toolkit dedicated to time-series data},
  author={Tavenard, Romain and Faouzi, Johann and Vandewiele, Gilles},

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -117,7 +117,7 @@ def _return_path(acc_cost_mat):
     return path[::-1]
 
 
-@njit()
+# @njit()
 def njit_cdist_dtw(dataset1, dataset2, global_constraint, sakoe_chiba_radius,
                    itakura_max_slope):
     """Compute the cross-similarity matrix between two datasets.
@@ -150,7 +150,7 @@ def njit_cdist_dtw(dataset1, dataset2, global_constraint, sakoe_chiba_radius,
     return cdist_arr
 
 
-@njit()
+# @njit()
 def njit_cdist_dtw_self(dataset, global_constraint, sakoe_chiba_radius,
                         itakura_max_slope):
     """Compute the cross-similarity matrix between a dataset and itself.
@@ -556,7 +556,7 @@ def _njit_itakura_mask(sz1, sz2, max_slope=2.):
     return mask
 
 
-@njit()
+# @njit()
 def itakura_mask(sz1, sz2, max_slope=2.):
     """Compute the Itakura mask.
 

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -117,7 +117,6 @@ def _return_path(acc_cost_mat):
     return path[::-1]
 
 
-# @njit()
 def njit_cdist_dtw(dataset1, dataset2, global_constraint, sakoe_chiba_radius,
                    itakura_max_slope):
     """Compute the cross-similarity matrix between two datasets.
@@ -150,7 +149,6 @@ def njit_cdist_dtw(dataset1, dataset2, global_constraint, sakoe_chiba_radius,
     return cdist_arr
 
 
-# @njit()
 def njit_cdist_dtw_self(dataset, global_constraint, sakoe_chiba_radius,
                         itakura_max_slope):
     """Compute the cross-similarity matrix between a dataset and itself.
@@ -546,7 +544,6 @@ def _njit_itakura_mask(sz1, sz2, max_slope=2.):
     return mask
 
 
-# @njit()
 def itakura_mask(sz1, sz2, max_slope=2.):
     """Compute the Itakura mask.
 

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -585,9 +585,9 @@ def compute_mask(s1, s2, global_constraint=0,
     """
     sz1 = s1.shape[0]
     sz2 = s2.shape[0]
-    if global_constraint == 1:
+    if global_constraint == 2:
         mask = sakoe_chiba_mask(sz1, sz2, radius=sakoe_chiba_radius)
-    elif global_constraint == 2:
+    elif global_constraint == 1:
         mask = itakura_mask(sz1, sz2, max_slope=itakura_max_slope)
     else:
         mask = numpy.zeros((sz1, sz2))

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -495,6 +495,15 @@ def sakoe_chiba_mask(sz1, sz2, radius=1):
     return mask
 
 
+def _njit_is_all_infinite(arr):
+    """Returns True iff all elements in array arr are equal to numpy.inf"""
+    arr_ = arr.reshape((-1, ))
+    for i in prange(len(arr_)):
+        if arr_[i] != numpy.inf:
+            return False
+    return True
+
+
 @njit()
 def itakura_mask(sz1, sz2, max_slope=2.):
     """Compute the Itakura mask.
@@ -556,12 +565,12 @@ def itakura_mask(sz1, sz2, max_slope=2.):
     # Post-check
     raise_warning = False
     for i in prange(sz1):
-        if not numpy.any(numpy.isfinite(mask[i])):
+        if _njit_is_all_infinite(mask[i]):
             raise_warning = True
             break
     if not raise_warning:
         for j in prange(sz2):
-            if not numpy.any(numpy.isfinite(mask[:, j])):
+            if _njit_is_all_infinite(mask[:, j]):
                 raise_warning = True
                 break
     if raise_warning:

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -495,6 +495,7 @@ def sakoe_chiba_mask(sz1, sz2, radius=1):
     return mask
 
 
+@njit()
 def _njit_is_all_infinite(arr):
     """Returns True iff all elements in array arr are equal to numpy.inf"""
     arr_ = arr.reshape((-1, ))

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -496,16 +496,6 @@ def sakoe_chiba_mask(sz1, sz2, radius=1):
 
 
 @njit()
-def _njit_is_all_infinite(arr):
-    """Returns True iff all elements in array arr are equal to numpy.inf"""
-    arr_ = arr.reshape((-1, ))
-    for i in prange(len(arr_)):
-        if arr_[i] != numpy.inf:
-            return False
-    return True
-
-
-@njit()
 def _njit_itakura_mask(sz1, sz2, max_slope=2.):
     """Compute the Itakura mask without checking that the constraints
     are feasible. In most cases, you should use itakura_mask instead.
@@ -591,12 +581,12 @@ def itakura_mask(sz1, sz2, max_slope=2.):
     # Post-check
     raise_warning = False
     for i in prange(sz1):
-        if _njit_is_all_infinite(mask[i]):
+        if not numpy.any(numpy.isfinite(mask[i])):
             raise_warning = True
             break
     if not raise_warning:
         for j in prange(sz2):
-            if _njit_is_all_infinite(mask[:, j]):
+            if not numpy.any(numpy.isfinite(mask[:, j])):
                 raise_warning = True
                 break
     if raise_warning:

--- a/tslearn/tests/test_metrics.py
+++ b/tslearn/tests/test_metrics.py
@@ -53,8 +53,13 @@ def test_constrained_paths():
     np.testing.assert_allclose(dtw_itak, euc_dist,
                                atol=1e-5)
 
-    # TODO: assert that a warning is raised in case of unfeasible
-    # itakura constraint
+    z = rng.randn(3 * n, d)
+    np.testing.assert_warns(RuntimeWarning, tslearn.metrics.dtw,
+                            x, z, global_constraint="itakura",
+                            itakura_max_slope=2.0)
+    np.testing.assert_warns(RuntimeWarning, tslearn.metrics.dtw,
+                            z, x, global_constraint="itakura",
+                            itakura_max_slope=2.0)
 
 
 

--- a/tslearn/tests/test_metrics.py
+++ b/tslearn/tests/test_metrics.py
@@ -36,6 +36,28 @@ def test_dtw():
                                atol=1e-5)
 
 
+def test_constrained_paths():
+    n, d = 10, 3
+    rng = np.random.RandomState(0)
+    x = rng.randn(n, d)
+    y = rng.randn(n, d)
+    dtw_sakoe = tslearn.metrics.dtw(x, y,
+                                    global_constraint="sakoe_chiba",
+                                    sakoe_chiba_radius=0)
+    dtw_itak = tslearn.metrics.dtw(x, y,
+                                   global_constraint="itakura",
+                                   itakura_max_slope=1.0)
+    euc_dist = np.linalg.norm(x - y)
+    np.testing.assert_allclose(dtw_sakoe, euc_dist,
+                               atol=1e-5)
+    np.testing.assert_allclose(dtw_itak, euc_dist,
+                               atol=1e-5)
+
+    # TODO: assert that a warning is raised in case of unfeasible
+    # itakura constraint
+
+
+
 def test_dtw_subseq():
     path, dist = tslearn.metrics.dtw_subsequence_path([2, 3],
                                                       [1., 2., 2., 3., 4.])


### PR DESCRIPTION
tslearn version: v0.2.0
Related to Issue: #140 

To be fixed:
1. itakura & sakoe-chiba are swapped in compute_mask (already fixed in initial commit)
2. for itakura: there should always be at least one path, whatever time series shapes, but this is not the case, eg:

```python
In [13]: from tslearn.metrics import itakura_mask                                                                                                                                                                                   

In [14]: itakura_mask(10, 3)                                                                                                                                                                                                        
Out[14]: 
array([[ 0., inf, inf],
       [inf, inf, inf],
       [inf, inf, inf],
       [inf,  0., inf],
       [inf,  0., inf],
       [inf,  0., inf],
       [inf,  0., inf],
       [inf, inf, inf],
       [inf, inf, inf],
       [inf, inf,  0.]])
```