### PR TITLE
Add utilities to cast from/to other python time series packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION Cython numpy>=1.14 scipy tensorflow keras
-  scikit-learn numba joblib>=0.12 pandas>=0.24
+  scikit-learn numba joblib>=0.12 pandas>=0.24 cesium
 - source activate test-environment
 - pip install pytest
 - if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then pip install coverage==4.3 "pytest-cov<2.6"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION Cython numpy>=1.14 scipy tensorflow keras
-  scikit-learn numba joblib>=0.12 pandas>=0.24 cesium
+  scikit-learn numba joblib>=0.12 pandas>=0.24
 - source activate test-environment
-- pip install pytest
+- pip install cesium pytest
 - if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then pip install coverage==4.3 "pytest-cov<2.6"; fi
 - pip install argparse
 - pip install codeclimate-test-reporter codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION Cython numpy>=1.14 scipy tensorflow keras
-  scikit-learn numba joblib>=0.12 pandas>=0.24
+  scikit-learn numba joblib>=0.12 pandas
 - source activate test-environment
 - pip install cesium pytest
 - if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then pip install coverage==4.3 "pytest-cov<2.6"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION Cython numpy>=1.14 scipy tensorflow keras
-  scikit-learn numba joblib>=0.12
+  scikit-learn numba joblib>=0.12 pandas
 - source activate test-environment
 - pip install pytest
 - if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then pip install coverage==4.3 "pytest-cov<2.6"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
 - conda update -q conda
 - conda info -a
 - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION Cython numpy>=1.14 scipy tensorflow keras
-  scikit-learn numba joblib>=0.12 pandas
+  scikit-learn numba joblib>=0.12 pandas>=0.24
 - source activate test-environment
 - pip install pytest
 - if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then pip install coverage==4.3 "pytest-cov<2.6"; fi

--- a/tslearn/docs/conf.py
+++ b/tslearn/docs/conf.py
@@ -20,7 +20,9 @@ import sphinx_bootstrap_theme
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # Uncomment for local build
-# sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
+if not on_rtd:
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../..'))
 
 # -- General configuration ------------------------------------------------
 

--- a/tslearn/docs/gen_modules/tslearn.utils.rst
+++ b/tslearn/docs/gen_modules/tslearn.utils.rst
@@ -25,7 +25,7 @@ tslearn.utils
 
    .. rubric:: Conversion functions
 
-   The following functions are provided in order to provide some level of
+   The following functions are provided for the sake of
    interoperability between standard Python packages for time series.
    They allow conversion between `tslearn` format and other libraries' formats.
 

--- a/tslearn/docs/gen_modules/tslearn.utils.rst
+++ b/tslearn/docs/gen_modules/tslearn.utils.rst
@@ -22,13 +22,25 @@ tslearn.utils
       save_timeseries_txt
       check_equal_size
       check_dims
-   
-   
+      to_pyts_dataset
+      from_pyts_dataset
+      to_sktime_dataset
+      from_sktime_dataset
+      to_cesium_dataset
+      from_cesium_dataset
+      to_seglearn_dataset
+      from_seglearn_dataset
+      to_tsfresh_dataset
+      from_tsfresh_dataset
+      to_stumpy_dataset
+      from_stumpy_dataset
+      to_pyflux_dataset
+      from_pyflux_dataset
 
-   
-   
-   
 
-   
-   
-   
+
+
+
+
+
+

--- a/tslearn/docs/gen_modules/tslearn.utils.rst
+++ b/tslearn/docs/gen_modules/tslearn.utils.rst
@@ -7,7 +7,7 @@ tslearn.utils
 
    
    
-   .. rubric:: Functions
+   .. rubric:: Generic functions
 
    .. autosummary::
       :toctree: utils
@@ -22,6 +22,17 @@ tslearn.utils
       save_timeseries_txt
       check_equal_size
       check_dims
+
+   .. rubric:: Conversion functions
+
+   The following functions are provided in order to provide some level of
+   interoperability between standard Python packages for time series.
+   They allow conversion between `tslearn` format and other libraries' formats.
+
+   .. autosummary::
+      :toctree: utils_conv
+      :template: function.rst
+
       to_pyts_dataset
       from_pyts_dataset
       to_sktime_dataset

--- a/tslearn/docs/index.rst
+++ b/tslearn/docs/index.rst
@@ -75,4 +75,5 @@ From here, you can navigate to:
     variablelength
     reference
     auto_examples/index
+    citing
 

--- a/tslearn/tests/test_utils.py
+++ b/tslearn/tests/test_utils.py
@@ -77,6 +77,13 @@ def test_conversions():
         )
     )
 
+    np.testing.assert_allclose(
+        tslearn_dataset,
+        tslearn.utils.from_cesium_dataset(
+            tslearn.utils.to_cesium_dataset(tslearn_dataset)
+        )
+    )
+
     tslearn_dataset = rng.randn(1, sz, d)
     np.testing.assert_allclose(
         tslearn_dataset,

--- a/tslearn/tests/test_utils.py
+++ b/tslearn/tests/test_utils.py
@@ -84,6 +84,13 @@ def test_conversions():
         )
     )
 
+    np.testing.assert_allclose(
+        tslearn_dataset,
+        tslearn.utils.from_tsfresh_dataset(
+            tslearn.utils.to_tsfresh_dataset(tslearn_dataset)
+        )
+    )
+
     tslearn_dataset = rng.randn(1, sz, d)
     np.testing.assert_allclose(
         tslearn_dataset,

--- a/tslearn/tests/test_utils.py
+++ b/tslearn/tests/test_utils.py
@@ -76,3 +76,11 @@ def test_conversions():
             tslearn.utils.to_stumpy_dataset(tslearn_dataset)
         )
     )
+
+    tslearn_dataset = rng.randn(1, sz, d)
+    np.testing.assert_allclose(
+        tslearn_dataset,
+        tslearn.utils.from_pyflux_dataset(
+            tslearn.utils.to_pyflux_dataset(tslearn_dataset)
+        )
+    )

--- a/tslearn/tests/test_utils.py
+++ b/tslearn/tests/test_utils.py
@@ -42,3 +42,37 @@ def test_label_categorizer():
     ref = np.array([1., 2., -1.])
 
     np.testing.assert_allclose(ref, y_tr)
+
+
+def test_conversions():
+    n, sz, d = 15, 10, 3
+    rng = np.random.RandomState(0)
+    tslearn_dataset = rng.randn(n, sz, d)
+
+    np.testing.assert_allclose(
+        tslearn_dataset,
+        tslearn.utils.from_pyts_dataset(
+            tslearn.utils.to_pyts_dataset(tslearn_dataset)
+        )
+    )
+
+    np.testing.assert_allclose(
+        tslearn_dataset,
+        tslearn.utils.from_sktime_dataset(
+            tslearn.utils.to_sktime_dataset(tslearn_dataset)
+        )
+    )
+
+    np.testing.assert_allclose(
+        tslearn_dataset,
+        tslearn.utils.from_seglearn_dataset(
+            tslearn.utils.to_seglearn_dataset(tslearn_dataset)
+        )
+    )
+
+    np.testing.assert_allclose(
+        tslearn_dataset,
+        tslearn.utils.from_stumpy_dataset(
+            tslearn.utils.to_stumpy_dataset(tslearn_dataset)
+        )
+    )

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -773,7 +773,7 @@ try:  # Ugly hack, not sure how to to it better
         -------
         Pandas data-frame
             sktime-formatted dataset (cf.
-            [link](https://alan-turing-institute.github.io/sktime/examples/loading_data.html))
+            `link <https://alan-turing-institute.github.io/sktime/examples/loading_data.html>`_)
 
         Examples
         --------
@@ -808,7 +808,7 @@ try:  # Ugly hack, not sure how to to it better
         ----------
         X: pandas data-frame
             sktime-formatted dataset (cf.
-            [link](https://alan-turing-institute.github.io/sktime/examples/loading_data.html))
+            `link <https://alan-turing-institute.github.io/sktime/examples/loading_data.html>`_)
 
         Returns
         -------
@@ -881,7 +881,7 @@ try:  # Ugly hack, not sure how to to it better
         -------
         Pandas data-frame
             pyflux-formatted dataset (cf.
-            [link](https://pyflux.readthedocs.io/en/latest/getting_started.html))
+            `link <https://pyflux.readthedocs.io/en/latest/getting_started.html>`_)
 
         Examples
         --------
@@ -986,7 +986,7 @@ try:  # Ugly hack, not sure how to to it better
         -------
         Pandas data-frame
             tsfresh-formatted dataset ("flat" data frame, as described
-            [there](https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe))
+            `there <https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe>`_)
 
         Examples
         --------
@@ -1025,7 +1025,7 @@ try:  # Ugly hack, not sure how to to it better
         ----------
         X: pandas data-frame
             tsfresh-formatted dataset ("flat" data frame, as described
-            [there](https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe))
+            `there <https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe>`_)
 
         Returns
         -------
@@ -1120,7 +1120,7 @@ try:
         -------
         list of cesium TimeSeries
             cesium-formatted dataset (cf.
-            [linl](http://cesium-ml.org/docs/api/cesium.time_series.html#cesium.time_series.TimeSeries))
+            `link <http://cesium-ml.org/docs/api/cesium.time_series.html#cesium.time_series.TimeSeries>`_)
 
         Examples
         --------
@@ -1164,7 +1164,7 @@ try:
         ----------
         X: list of cesium TimeSeries
             cesium-formatted dataset (cf.
-            [linl](http://cesium-ml.org/docs/api/cesium.time_series.html#cesium.time_series.TimeSeries))
+            `link <http://cesium-ml.org/docs/api/cesium.time_series.html#cesium.time_series.TimeSeries>`_)
 
         Returns
         -------

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -1062,7 +1062,7 @@ try:
             return tslearn_ts
 
         if not isinstance(X, list) or \
-            [type(ts) for ts in X] != [TimeSeries] * len(X):
+                [type(ts) for ts in X] != [TimeSeries] * len(X):
             raise ValueError("X is not a valid input cesium array. "
                              "A list of cesium TimeSeries is expected.")
         dataset = [format_to_tslearn(ts) for ts in X]

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -793,7 +793,7 @@ try:  # Ugly hack, not sure how to to it better
         Notes
         -----
         Conversion from/to sktime format requires pandas to be installed.
-        """
+        """  # noqa: E501
         X_ = check_dataset(X)
         X_pd = pd.DataFrame(dtype=numpy.float32)
         for dim in range(X_.shape[2]):
@@ -841,7 +841,7 @@ try:  # Ugly hack, not sure how to to it better
         Notes
         -----
         Conversion from/to sktime format requires pandas to be installed.
-        """
+        """  # noqa: E501
         if not isinstance(X, pd.DataFrame):
             raise ValueError("X is not a valid input sktime array. "
                              "A pandas DataFrame is expected.")
@@ -906,7 +906,7 @@ try:  # Ugly hack, not sure how to to it better
         Notes
         -----
         Conversion from/to pyflux format requires pandas to be installed.
-        """
+        """  # noqa: E501
         X_ = check_dataset(X,
                            force_equal_length=True,
                            force_single_time_series=True)
@@ -1002,7 +1002,7 @@ try:  # Ugly hack, not sure how to to it better
         Notes
         -----
         Conversion from/to tsfresh format requires pandas to be installed.
-        """
+        """  # noqa: E501
         X_ = check_dataset(X)
         n, sz, d = X_.shape
         dataframes = []
@@ -1061,7 +1061,7 @@ try:  # Ugly hack, not sure how to to it better
         Notes
         -----
         Conversion from/to tsfresh format requires pandas to be installed.
-        """
+        """  # noqa: E501
         if not isinstance(X, pd.DataFrame):
             raise ValueError("X is not a valid input tsfresh array. "
                              "A pandas DataFrame is expected.")
@@ -1146,7 +1146,7 @@ try:
         Notes
         -----
         Conversion from/to cesium format requires cesium to be installed.
-        """
+        """  # noqa: E501
         def transpose_or_flatten(ts):
             ts_ = ts[:ts_size(ts)]
             if ts.shape[1] == 1:
@@ -1188,7 +1188,7 @@ try:
         Notes
         -----
         Conversion from/to cesium format requires cesium to be installed.
-        """
+        """  # noqa: E501
         def format_to_tslearn(ts):
             try:
                 ts.sort()

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -592,6 +592,72 @@ def from_pyts_dataset(X):
                          "are {}".format(X_.shape))
 
 
+def to_sktime_dataset(X):
+    """Transform a tslearn-compatible dataset into a sktime dataset.
+
+    Parameters
+    ----------
+    X: array, shape = (n_ts, sz, d)
+        tslearn-formatted dataset to be cast to sktime format
+
+    Returns
+    -------
+    array, shape=(n_ts, d, sz)
+        sktime-formatted dataset
+
+    Examples
+    --------
+    >>> tslearn_arr = numpy.random.randn(10, 16, 1)
+    >>> sktime_arr = to_sktime_dataset(tslearn_arr)
+    >>> sktime_arr.shape
+    (10, 1, 16)
+    >>> tslearn_arr = numpy.random.randn(10, 16, 2)
+    >>> sktime_arr = to_sktime_dataset(tslearn_arr)
+    >>> sktime_arr.shape
+    (10, 2, 16)
+    """
+    X_ = check_dataset(X)  # TODO: unequal-length case???
+    return X_.transpose((0, 2, 1))
+
+
+def from_sktime_dataset(X):
+    """Transform a sktime-compatible dataset into a tslearn dataset.
+
+    Parameters
+    ----------
+    X: array, shape = (n_ts, d, sz)
+        sktime-formatted dataset
+
+    Returns
+    -------
+    array, shape=(n_ts, sz, d)
+        tslearn-formatted dataset
+
+    Examples
+    --------
+    >>> sktime_arr = numpy.random.randn(10, 1, 16)
+    >>> tslearn_arr = from_sktime_dataset(sktime_arr)
+    >>> tslearn_arr.shape
+    (10, 16, 1)
+    >>> sktime_arr = numpy.random.randn(10, 2, 16)
+    >>> tslearn_arr = from_sktime_dataset(sktime_arr)
+    >>> tslearn_arr.shape
+    (10, 16, 2)
+    >>> sktime_arr = numpy.random.randn(10)
+    >>> from_sktime_dataset(sktime_arr)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    ValueError: X is not a valid input sktime array.
+    """
+    X_ = check_array(X, ensure_2d=False, allow_nd=True)
+    if X_.ndim == 3:
+        return X_.transpose((0, 2, 1))
+    else:
+        raise ValueError("X is not a valid input sktime array. "
+                         "Its dimensions, once cast to numpy.ndarray "
+                         "are {}".format(X_.shape))
+
+
 class LabelCategorizer(BaseEstimator, TransformerMixin):
     """Transformer to transform indicator-based labels into categorical ones.
 

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -490,6 +490,22 @@ def check_dataset(X, force_univariate=False, force_equal_length=False):
     ValueError
         Raised if X is not a valid dataset, or one of the constraints is not
         satisfied.
+
+    Examples
+    --------
+    >>> X = [[1, 2, 3], [1, 2, 3, 4]]
+    >>> X_new = check_dataset(X)
+    >>> X_new.shape
+    (2, 4, 1)
+    >>> check_dataset(X, force_equal_length=True)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    ValueError: All the time series in the array should be of equal lengths.
+    >>> other_X = numpy.random.randn(3, 10, 2)
+    >>> check_dataset(other_X, force_univariate=True)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    ValueError: Array should be univariate and is of shape: (3, 10, 2)
     """
     X_ = to_time_series_dataset(X)
     if force_univariate and X_.shape[2] != 1:

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -497,12 +497,18 @@ def check_dataset(X, force_univariate=False, force_equal_length=False):
     >>> X_new = check_dataset(X)
     >>> X_new.shape
     (2, 4, 1)
-    >>> check_dataset(X, force_equal_length=True)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_dataset(
+    ...     X,
+    ...     force_equal_length=True
+    ... )  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     ValueError: All the time series in the array should be of equal lengths.
     >>> other_X = numpy.random.randn(3, 10, 2)
-    >>> check_dataset(other_X, force_univariate=True)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    >>> check_dataset(
+    ...     other_X,
+    ...     force_univariate=True
+    ... )  # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
     ...
     ValueError: Array should be univariate and is of shape: (3, 10, 2)
@@ -695,11 +701,13 @@ def to_stumpy_dataset(X):
     (2, 16)
     """
     X_ = check_dataset(X)
+
     def transpose_or_flatten(ts):
         if ts.shape[1] == 1:
             return ts.reshape((-1, ))
         else:
             return ts.transpose()
+
     return [transpose_or_flatten(Xi[:ts_size(Xi)]) for Xi in X_]
 
 
@@ -735,11 +743,8 @@ def from_stumpy_dataset(X):
     return to_time_series_dataset([transpose_or_expand(Xi) for Xi in X])
 
 
-
-
 try:  # Ugly hack, not sure how to to it better
     import pandas as pd
-
 
     def to_sktime_dataset(X):
         """Transform a tslearn-compatible dataset into a sktime dataset.
@@ -777,7 +782,6 @@ try:  # Ugly hack, not sure how to to it better
                                        for Xi in X_]
         return X_pd
 
-
     def from_sktime_dataset(X):
         """Transform a sktime-compatible dataset into a tslearn dataset.
 
@@ -807,7 +811,9 @@ try:  # Ugly hack, not sure how to to it better
         >>> tslearn_arr.shape
         (2, 4, 2)
         >>> sktime_arr = numpy.random.randn(10, 1, 16)
-        >>> from_sktime_dataset(sktime_arr)  # doctest: +IGNORE_EXCEPTION_DETAIL
+        >>> from_sktime_dataset(
+        ...     sktime_arr
+        ... )  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         ...
         ValueError: X is not a valid input sktime array.
@@ -847,7 +853,6 @@ except ImportError:
     def from_sktime_dataset(X):
         raise ImportWarning("Conversion from/to sktime cannot be performed "
                             "if pandas is not installed.")
-
 
 
 class LabelCategorizer(BaseEstimator, TransformerMixin):

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -658,6 +658,76 @@ def from_sktime_dataset(X):
                          "are {}".format(X_.shape))
 
 
+def to_seglearn_dataset(X):
+    """Transform a tslearn-compatible dataset into a seglearn dataset.
+
+    Parameters
+    ----------
+    X: array, shape = (n_ts, sz, d)
+        tslearn-formatted dataset to be cast to seglearn format
+
+    Returns
+    -------
+    array of arrays, shape=(n_ts, )
+        seglearn-formatted dataset. i-th sub-array in the list has shape
+        (sz_i, d)
+
+    Examples
+    --------
+    >>> tslearn_arr = numpy.random.randn(10, 16, 1)
+    >>> seglearn_arr = to_seglearn_dataset(tslearn_arr)
+    >>> seglearn_arr.shape
+    (10, 16, 1)
+    >>> tslearn_arr = numpy.random.randn(10, 16, 2)
+    >>> seglearn_arr = to_seglearn_dataset(tslearn_arr)
+    >>> seglearn_arr.shape
+    (10, 16, 2)
+    >>> tslearn_arr = [numpy.random.randn(16, 2), numpy.random.randn(10, 2)]
+    >>> seglearn_arr = to_seglearn_dataset(tslearn_arr)
+    >>> seglearn_arr.shape
+    (2,)
+    >>> seglearn_arr[0].shape
+    (16, 2)
+    >>> seglearn_arr[1].shape
+    (10, 2)
+    """
+    X_ = to_time_series_dataset(X)
+    return numpy.array([Xi[:ts_size(Xi)] for Xi in X_])
+
+
+def from_seglearn_dataset(X):
+    """Transform a seglearn-compatible dataset into a tslearn dataset.
+
+    Parameters
+    ----------
+    X: list of arrays, or array of arrays, shape = (n_ts, )
+        seglearn-formatted dataset. i-th sub-array in the list has shape
+        (sz_i, d)
+
+    Returns
+    -------
+    array, shape=(n_ts, sz, d), where sz is the maximum of all array lengths
+        tslearn-formatted dataset
+
+    Examples
+    --------
+    >>> seglearn_arr = [numpy.random.randn(10, 1), numpy.random.randn(10, 1)]
+    >>> tslearn_arr = from_seglearn_dataset(seglearn_arr)
+    >>> tslearn_arr.shape
+    (2, 10, 1)
+    >>> seglearn_arr = [numpy.random.randn(10, 1), numpy.random.randn(5, 1)]
+    >>> tslearn_arr = from_seglearn_dataset(seglearn_arr)
+    >>> tslearn_arr.shape
+    (2, 10, 1)
+    >>> seglearn_arr = numpy.random.randn(2, 10, 1)
+    >>> tslearn_arr = from_seglearn_dataset(seglearn_arr)
+    >>> tslearn_arr.shape
+    (2, 10, 1)
+    """
+    return to_time_series_dataset(X)
+
+
+
 class LabelCategorizer(BaseEstimator, TransformerMixin):
     """Transformer to transform indicator-based labels into categorical ones.
 

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -857,7 +857,7 @@ try:  # Ugly hack, not sure how to to it better
         for di in range(d):
             for i in range(n):
                 sz = X["dim_%d" % di][i].size
-                tslearn_arr[i, :sz, di] = X["dim_%d" % di][i].to_numpy()
+                tslearn_arr[i, :sz, di] = X["dim_%d" % di][i].array.copy()
         return tslearn_arr
 
     def to_pyflux_dataset(X):
@@ -952,7 +952,7 @@ try:  # Ugly hack, not sure how to to it better
         tslearn_arr = numpy.empty((n, max_sz, d))
         tslearn_arr[:] = numpy.nan
         for di, dim_name in enumerate(data_dimensions):
-            data = X[dim_name].to_numpy()
+            data = X[dim_name].array.copy()
             sz = len(data)
             tslearn_arr[0, :sz, di] = data
         return tslearn_arr

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -773,7 +773,7 @@ try:  # Ugly hack, not sure how to to it better
         -------
         Pandas data-frame
             sktime-formatted dataset (cf.
-            https://alan-turing-institute.github.io/sktime/examples/loading_data.html)
+            [link](https://alan-turing-institute.github.io/sktime/examples/loading_data.html))
 
         Examples
         --------
@@ -807,7 +807,8 @@ try:  # Ugly hack, not sure how to to it better
         Parameters
         ----------
         X: pandas data-frame
-            sktime-formatted dataset
+            sktime-formatted dataset (cf.
+            [link](https://alan-turing-institute.github.io/sktime/examples/loading_data.html))
 
         Returns
         -------
@@ -880,7 +881,7 @@ try:  # Ugly hack, not sure how to to it better
         -------
         Pandas data-frame
             pyflux-formatted dataset (cf.
-            https://pyflux.readthedocs.io/en/latest/getting_started.html)
+            [link](https://pyflux.readthedocs.io/en/latest/getting_started.html))
 
         Examples
         --------
@@ -984,8 +985,8 @@ try:  # Ugly hack, not sure how to to it better
         Returns
         -------
         Pandas data-frame
-            tsfresh-formatted dataset ("flat" data frame, as described there:
-            https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe)
+            tsfresh-formatted dataset ("flat" data frame, as described
+            [there](https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe))
 
         Examples
         --------
@@ -1023,8 +1024,8 @@ try:  # Ugly hack, not sure how to to it better
         Parameters
         ----------
         X: pandas data-frame
-            tsfresh-formatted dataset ("flat" data frame, as described there:
-            https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe)
+            tsfresh-formatted dataset ("flat" data frame, as described
+            [there](https://tsfresh.readthedocs.io/en/latest/text/data_formats.html#input-option-1-flat-dataframe))
 
         Returns
         -------
@@ -1119,7 +1120,7 @@ try:
         -------
         list of cesium TimeSeries
             cesium-formatted dataset (cf.
-            http://cesium-ml.org/docs/api/cesium.time_series.html#cesium.time_series.TimeSeries)
+            [linl](http://cesium-ml.org/docs/api/cesium.time_series.html#cesium.time_series.TimeSeries))
 
         Examples
         --------
@@ -1162,7 +1163,8 @@ try:
         Parameters
         ----------
         X: list of cesium TimeSeries
-            cesium-formatted dataset
+            cesium-formatted dataset (cf.
+            [linl](http://cesium-ml.org/docs/api/cesium.time_series.html#cesium.time_series.TimeSeries))
 
         Returns
         -------

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -1011,7 +1011,7 @@ try:  # Ugly hack, not sure how to to it better
             Xi_ = Xi[:ts_size(Xi)]
             sz = Xi_.shape[0]
             df["time"] = numpy.arange(sz)
-            df["id"] = numpy.zeros((sz, ))
+            df["id"] = numpy.zeros((sz, ), dtype=numpy.int32) + i
             for di in range(d):
                 df["dim_%d" % di] = Xi_[:, di]
             dataframes.append(df)

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -857,7 +857,7 @@ try:  # Ugly hack, not sure how to to it better
         for di in range(d):
             for i in range(n):
                 sz = X["dim_%d" % di][i].size
-                tslearn_arr[i, :sz, di] = X["dim_%d" % di][i].array.copy()
+                tslearn_arr[i, :sz, di] = X["dim_%d" % di][i].values.copy()
         return tslearn_arr
 
     def to_pyflux_dataset(X):
@@ -952,7 +952,7 @@ try:  # Ugly hack, not sure how to to it better
         tslearn_arr = numpy.empty((n, max_sz, d))
         tslearn_arr[:] = numpy.nan
         for di, dim_name in enumerate(data_dimensions):
-            data = X[dim_name].array.copy()
+            data = X[dim_name].values.copy()
             sz = len(data)
             tslearn_arr[0, :sz, di] = data
         return tslearn_arr

--- a/tslearn/utils.py
+++ b/tslearn/utils.py
@@ -543,8 +543,13 @@ def to_pyts_dataset(X):
     >>> pyts_arr = to_pyts_dataset(tslearn_arr)
     >>> pyts_arr.shape
     (10, 2, 16)
+    >>> tslearn_arr = [numpy.random.randn(16, 1), numpy.random.randn(10, 1)]
+    >>> to_pyts_dataset(tslearn_arr)  # doctest: +IGNORE_EXCEPTION_DETAIL
+    Traceback (most recent call last):
+    ...
+    ValueError: All the time series in the array should be of equal lengths
     """
-    X_ = check_dataset(X)
+    X_ = check_dataset(X, force_equal_length=True)
     if X_.shape[2] == 1:
         return X_.reshape((X_.shape[0], -1))
     else:


### PR DESCRIPTION
The idea is to have a way to easily cast time series datasets from/to tslearn format to/from formats used by other python time series libraries.

I started with `pyts`. @johannfaouzi could you tell if what I assume to be the type of `pyts` datasets is OK or not?

The full list I would like to have would be:
* [x] pyts
* [x] sktime
* [x] cesium-ml
* [x] seglearn
* [x] tsfresh
* [x] stumpy
* [x] pyflux