### PR TITLE
MAINT Include test folder in wheels

### DIFF
--- a/tslearn/__init__.py
+++ b/tslearn/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __bibtex__ = r"""@misc{tslearn,
  title={tslearn: A machine learning toolkit dedicated to time-series data},
  author={Tavenard, Romain and Faouzi, Johann and Vandewiele, Gilles},

--- a/tslearn/tests/test_estimators.py
+++ b/tslearn/tests/test_estimators.py
@@ -18,7 +18,8 @@ from sklearn.utils.estimator_checks import (
     check_no_attributes_set_in_init,
     check_parameters_default_constructible
 )
-from sklearn_patches import (check_clustering,
+from tslearn.tests.sklearn_patches import (
+                             check_clustering,
                              check_non_transf_est_n_iter,
                              check_fit_idempotent,
                              check_classifiers_classes,
@@ -30,7 +31,7 @@ from sklearn_patches import (check_clustering,
                              check_classifiers_cont_target,
                              check_pipeline_consistency,
                              yield_all_checks)
-from sklearn_patches import _safe_tags
+from tslearn.tests.sklearn_patches import _safe_tags
 import warnings
 import pytest
 

--- a/tslearn/tests/test_shapelets.py
+++ b/tslearn/tests/test_shapelets.py
@@ -1,13 +1,16 @@
 import numpy as np
+import pytest
+from sklearn.model_selection import cross_validate
 
-from tslearn.shapelets import ShapeletModel, SerializableShapeletModel
 from tslearn.utils import to_time_series
-import tslearn
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 
 def test_shapelets():
+    pytest.importorskip('keras')
+    from tslearn.shapelets import ShapeletModel
+
     n, sz, d = 15, 10, 2
     rng = np.random.RandomState(0)
     time_series = rng.randn(n, sz, d)
@@ -26,7 +29,6 @@ def test_shapelets():
                                np.array([0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 0,
                                          1, 0]))
 
-    from sklearn.model_selection import cross_validate
     cross_validate(clf, time_series, y, cv=2)
 
     model = ShapeletModel(n_shapelets_per_size={3: 2, 4: 1},
@@ -39,6 +41,9 @@ def test_shapelets():
 
 
 def test_serializable_shapelets():
+    pytest.importorskip('keras')
+    from tslearn.shapelets import SerializableShapeletModel
+
     n, sz, d = 15, 10, 2
     rng = np.random.RandomState(0)
     time_series = rng.randn(n, sz, d)


### PR DESCRIPTION
Because the test folder didn't have an `__init__.py` file it was not considered to be a python module and was not included in wheels.

This adds it, which would make running tests on wheels easier in #150 with,
```
pytest --pyargs tslearn
```
this will run tests on the installed version of tslearn (installed from wheels or by other means).