### PR TITLE
[WIP] Implement MM algorithm for DBA

### DIFF
--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -5,11 +5,13 @@ barycenter computation.
 
 # Code for soft DTW is by Mathieu Blondel under Simplified BSD license
 
+from __future__ import division
 import numpy
 from scipy.interpolate import interp1d
 from scipy.optimize import minimize
 from sklearn.exceptions import ConvergenceWarning
 import warnings
+from sklearn.utils import check_random_state
 
 from tslearn.utils import to_time_series_dataset, check_equal_size, \
     to_time_series, ts_size
@@ -273,6 +275,51 @@ def _mm_assignment(X, barycenter, weights, metric_params=None):
     cost /= weights.sum()
     return list_p_k, cost
 
+def _subgradient_valence_warping(list_p_k, barycenter_size, weights):
+    """Compute Valence and Warping matrices from paths.
+
+    Valence matrices are denoted :math:`V^{(k)}` and Warping matrices are
+    :math:`W^{(k)}` in [1]_.
+
+    This function returns a list of :math:`V^{(k)}` diagonals (as a vector)
+    and a list of :math:`W^{(k)}` matrices.
+
+    Parameters
+    ----------
+    list_p_k : list of index pairs
+        Warping paths
+
+    barycenter_size : int
+        Size of the barycenter to generate.
+
+    weights: array
+        Weights of each X[i]. Must be the same size as len(X).
+
+    Returns
+    -------
+    list of numpy.array of shape (barycenter_size, )
+        list of weighted :math:`V^{(k)}` diagonals (as a vector)
+
+    list of numpy.array of shape (barycenter_size, sz_k)
+        list of weighted :math:`W^{(k)}` matrices
+
+    References
+    ----------
+
+    .. [1] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
+       for Averaging in Dynamic Time Warping Spaces.
+       Pattern Recognition, 74, 340-358.
+    """
+    list_v_k = []
+    list_w_k = []
+    for k, p_k in enumerate(list_p_k):
+        sz_k = p_k[-1][1] + 1
+        w_k = numpy.zeros((barycenter_size, sz_k))
+        for i, j in p_k:
+            w_k[i, j] = 1.
+        list_w_k.append(w_k * weights[k])
+        list_v_k.append(w_k.sum(axis=1) * weights[k])
+    return list_v_k, list_w_k
 
 def _mm_valence_warping(list_p_k, barycenter_size, weights):
     """Compute Valence and Warping matrices from paths.
@@ -309,17 +356,14 @@ def _mm_valence_warping(list_p_k, barycenter_size, weights):
        for Averaging in Dynamic Time Warping Spaces.
        Pattern Recognition, 74, 340-358.
     """
-    diag_sum_v_k = numpy.zeros((barycenter_size, ))
-    list_w_k = []
-    for k, p_k in enumerate(list_p_k):
-        sz_k = p_k[-1][1] + 1
-        w_k = numpy.zeros((barycenter_size, sz_k))
-        for i, j in p_k:
-            w_k[i, j] = 1.
-        list_w_k.append(w_k * weights[k])
-        diag_sum_v_k += w_k.sum(axis=1) * weights[k]
+    list_v_k, list_w_k = _subgradient_valence_warping(
+        list_p_k=list_p_k,
+        barycenter_size=barycenter_size,
+        weights=weights)
+    diag_sum_v_k = numpy.zeros(list_v_k[0].shape)
+    for v_k in list_v_k:
+        diag_sum_v_k += v_k
     return diag_sum_v_k, list_w_k
-
 
 def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
     """Update barycenters using the formula from Algorithm 2 in [1]_.
@@ -355,12 +399,58 @@ def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
     barycenter = numpy.diag(1. / diag_sum_v_k).dot(sum_w_x)
     return barycenter
 
+def _subgradient_update_barycenter(X, list_diag_v_k, list_w_k, weights_sum,
+                                   barycenter, eta):
+    """Update barycenters using the formula from Algorithm 1 in [1]_.
+
+    Parameters
+    ----------
+    X : numpy.array of shape (n, sz, d)
+        Time-series to be averaged
+
+    list_diag_v_k : list of numpy.array of shape (barycenter_size, )
+        list of weighted :math:`V^{(k)}` diagonals (as vectors)
+
+    list_w_k : list of numpy.array of shape (barycenter_size, sz_k)
+        list of weighted :math:`W^{(k)}` matrices
+
+    weights_sum : float
+        sum of weights applied to matrices :math:`V^{(k)}` and :math:`W^{(k)}`
+
+    barycenter : numpy.array of shape (barycenter_size, d)
+        Barycenter as computed at the previous iteration of the algorithm
+
+    eta : float
+        Step-size for the subgradient descent algorithm
+
+    Returns
+    -------
+    numpy.array of shape (barycenter_size, d)
+        Updated barycenter
+
+    References
+    ----------
+
+    .. [1] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
+       for Averaging in Dynamic Time Warping Spaces.
+       Pattern Recognition, 74, 340-358.
+    """
+    d = X.shape[2]
+    barycenter_size = barycenter.shape[0]
+    delta_bar = numpy.zeros((barycenter_size, d))
+    for k, (v_k, w_k, x_k) in enumerate(zip(list_diag_v_k, list_w_k, X)):
+        delta_bar += v_k.reshape((-1, 1)) * barycenter
+        delta_bar -= w_k.dot(x_k[:ts_size(x_k)])
+    barycenter -= (2. * eta / weights_sum) * delta_bar
+    return barycenter
+
 
 def dtw_barycenter_averaging(X, barycenter_size=None, init_barycenter=None,
                              max_iter=30, tol=1e-5, weights=None,
                              metric_params=None,
                              verbose=False):
-    """DTW Barycenter Averaging (DBA) method.
+    """DTW Barycenter Averaging (DBA) method estimated through
+    Expectation-Maximization algorithm.
 
     DBA was originally presented in [1]_.
     This implementation is based on a idea from [2]_ (Majorize-Minimize Mean
@@ -466,6 +556,142 @@ def dtw_barycenter_averaging(X, barycenter_size=None, init_barycenter=None,
         if verbose:
             print("[DBA] epoch %d, cost: %.3f" % (it + 1, cost))
         barycenter = _mm_update_barycenter(X_, diag_sum_v_k, list_w_k)
+        if abs(cost_prev - cost) < tol:
+            break
+        elif cost_prev < cost:
+            warnings.warn("DBA loss is increasing while it should not be. "
+                          "Stopping optimization.", ConvergenceWarning)
+            break
+        else:
+            cost_prev = cost
+    return barycenter
+
+
+def dtw_barycenter_averaging_subgradient(X, barycenter_size=None,
+                                         init_barycenter=None, max_iter=30,
+                                         initial_step_size=.05,
+                                         final_step_size=.005,
+                                         tol=1e-5, random_state=None,
+                                         weights=None,
+                                         metric_params=None, verbose=False):
+    """DTW Barycenter Averaging (DBA) method estimated through subgradient
+    descent algorithm.
+
+    DBA was originally presented in [1]_.
+    This implementation is based on a idea from [2]_ (Stochastic Subgradient
+    Mean Algorithm).
+
+    Parameters
+    ----------
+    X : array-like, shape=(n_ts, sz, d)
+        Time series dataset.
+
+    barycenter_size : int or None (default: None)
+        Size of the barycenter to generate. If None, the size of the barycenter
+        is that of the data provided at fit
+        time or that of the initial barycenter if specified.
+
+    init_barycenter : array or None (default: None)
+        Initial barycenter to start from for the optimization process.
+
+    max_iter : int (default: 30)
+        Number of iterations of the Expectation-Maximization optimization
+        procedure.
+
+    initial_step_size : float (default: 0.05)
+        Initial step size for the subgradient descent algorithm.
+        Default value is the one suggested in [2]_.
+
+    final_step_size : float (default: 0.005)
+        Final step size for the subgradient descent algorithm.
+        Default value is the one suggested in [2]_.
+
+    tol : float (default: 1e-5)
+        Tolerance to use for early stopping: if the decrease in cost is lower
+        than this value, the
+        Expectation-Maximization procedure stops.
+
+    random_state : int, RandomState instance or None, optional (default=None)
+        If int, random_state is the seed used by the random number generator;
+        If RandomState instance, random_state is the random number generator;
+        If None, the random number generator is the RandomState instance used
+        by `np.random`.
+
+    weights: None or array
+        Weights of each X[i]. Must be the same size as len(X).
+        If None, uniform weights are used.
+
+    metric_params: dict or None (default: None)
+        DTW constraint parameters to be used.
+        See :ref:`tslearn.metrics.dtw_path <fun-tslearn.metrics.dtw_path>` for
+        a list of accepted parameters
+        If None, no constraint is used for DTW computations.
+
+    verbose : boolean (default: False)
+        Whether to print information about the cost at each iteration or not.
+
+    Returns
+    -------
+    numpy.array of shape (barycenter_size, d) or (sz, d) if barycenter_size \
+            is None
+        DBA barycenter of the provided time series dataset.
+
+    Examples
+    --------
+    >>> time_series = [[1, 2, 3, 4], [1, 2, 4, 5]]
+    >>> dtw_barycenter_averaging_subgradient(
+    ...     time_series,
+    ...     max_iter=10,
+    ...     random_state=0
+    ... )  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
+    array([[1. ],
+           [2. ],
+           [3.5...],
+           [4.5...]])
+
+    References
+    ----------
+    .. [1] F. Petitjean, A. Ketterlin & P. Gancarski. A global averaging method
+       for dynamic time warping, with applications to clustering. Pattern
+       Recognition, Elsevier, 2011, Vol. 44, Num. 3, pp. 678-693
+
+    .. [2] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
+       for Averaging in Dynamic Time Warping Spaces.
+       Pattern Recognition, 74, 340-358.
+    """
+    rng = check_random_state(random_state)
+
+    X_ = to_time_series_dataset(X)
+    if barycenter_size is None:
+        barycenter_size = X_.shape[1]
+    weights = _set_weights(weights, X_.shape[0])
+    if init_barycenter is None:
+        barycenter = _init_avg(X_, barycenter_size)
+    else:
+        barycenter_size = init_barycenter.shape[0]
+        barycenter = init_barycenter
+    cost_prev, cost = numpy.inf, numpy.inf
+    eta = initial_step_size
+    n = X_.shape[0]
+    for it in range(max_iter):
+        shuffled_indices = rng.permutation(n)
+        for idx in shuffled_indices:
+            Xi = X_[idx:idx+1]
+            wi = weights[idx:idx+1]
+            list_p_k, cost = _mm_assignment(Xi, barycenter, weights,
+                                            metric_params)
+            list_diag_v_k, list_w_k = _subgradient_valence_warping(
+                list_p_k,
+                barycenter_size,
+                wi
+            )
+            if verbose:
+                print("[DBA] epoch %d, cost: %.3f" % (it + 1, cost))
+            barycenter = _subgradient_update_barycenter(Xi, list_diag_v_k,
+                                                        list_w_k, wi.sum(),
+                                                        barycenter, eta)
+            if it == 0:
+                eta -= (initial_step_size - final_step_size) / n
         if abs(cost_prev - cost) < tol:
             break
         elif cost_prev < cost:

--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -330,11 +330,8 @@ def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
 
     Returns
     -------
-    list of index pairs
-        Warping paths
-
-    float
-        Current alignment cost
+    numpy.array of shape (barycenter_size, d)
+        Updated barycenter
 
     References
     ----------

--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -121,6 +121,8 @@ def dtw_barycenter_averaging_petitjean(X, barycenter_size=None,
     """DTW Barycenter Averaging (DBA) method.
 
     DBA was originally presented in [1]_.
+    This implementation is not the one documented in the API, but is kept
+    in the codebase to check the documented one for non-regression.
 
     Parameters
     ----------
@@ -190,6 +192,11 @@ def dtw_barycenter_averaging_petitjean(X, barycenter_size=None,
     array([[1.5       ],
            [3.        ],
            [4.33333333]])
+    >>> dtw_barycenter_averaging_petitjean([[0, 0, 0], [10, 10, 10]],
+    ...                                    weights=numpy.array([0.75, 0.25]))
+    array([[2.5],
+           [2.5],
+           [2.5]])
 
     References
     ----------
@@ -310,7 +317,7 @@ def _mm_valence_warping(list_p_k, barycenter_size, weights):
         for i, j in p_k:
             w_k[i, j] = 1.
         list_w_k.append(w_k * weights[k])
-        diag_sum_v_k += w_k.sum(axis=1)
+        diag_sum_v_k += w_k.sum(axis=1) * weights[k]
     return diag_sum_v_k, list_w_k
 
 
@@ -426,6 +433,11 @@ def dtw_barycenter_averaging(X, barycenter_size=None, init_barycenter=None,
     array([[1.5       ],
            [3.        ],
            [4.33333333]])
+    >>> dtw_barycenter_averaging([[0, 0, 0], [10, 10, 10]], max_iter=1,
+    ...                          weights=numpy.array([0.75, 0.25]))
+    array([[2.5],
+           [2.5],
+           [2.5]])
 
     References
     ----------

--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -275,6 +275,7 @@ def _mm_assignment(X, barycenter, weights, metric_params=None):
     cost /= weights.sum()
     return list_p_k, cost
 
+
 def _subgradient_valence_warping(list_p_k, barycenter_size, weights):
     """Compute Valence and Warping matrices from paths.
 
@@ -321,6 +322,7 @@ def _subgradient_valence_warping(list_p_k, barycenter_size, weights):
         list_v_k.append(w_k.sum(axis=1) * weights[k])
     return list_v_k, list_w_k
 
+
 def _mm_valence_warping(list_p_k, barycenter_size, weights):
     """Compute Valence and Warping matrices from paths.
 
@@ -365,6 +367,7 @@ def _mm_valence_warping(list_p_k, barycenter_size, weights):
         diag_sum_v_k += v_k
     return diag_sum_v_k, list_w_k
 
+
 def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
     """Update barycenters using the formula from Algorithm 2 in [1]_.
 
@@ -398,6 +401,7 @@ def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
         sum_w_x += w_k.dot(x_k[:ts_size(x_k)])
     barycenter = numpy.diag(1. / diag_sum_v_k).dot(sum_w_x)
     return barycenter
+
 
 def _subgradient_update_barycenter(X, list_diag_v_k, list_w_k, weights_sum,
                                    barycenter, eta):

--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -113,10 +113,11 @@ def _petitjean_cost(X, barycenter, assign, weights):
     return cost / weights.sum()
 
 
-def dtw_barycenter_averaging(X, barycenter_size=None, init_barycenter=None,
-                             max_iter=30, tol=1e-5, weights=None,
-                             metric_params=None,
-                             verbose=False):
+def dtw_barycenter_averaging_petitjean(X, barycenter_size=None,
+                                       init_barycenter=None,
+                                       max_iter=30, tol=1e-5, weights=None,
+                                       metric_params=None,
+                                       verbose=False):
     """DTW Barycenter Averaging (DBA) method.
 
     DBA was originally presented in [1]_.
@@ -165,26 +166,27 @@ def dtw_barycenter_averaging(X, barycenter_size=None, init_barycenter=None,
     Examples
     --------
     >>> time_series = [[1, 2, 3, 4], [1, 2, 4, 5]]
-    >>> dtw_barycenter_averaging(time_series, max_iter=5)
+    >>> dtw_barycenter_averaging_petitjean(time_series, max_iter=5)
     array([[1. ],
            [2. ],
            [3.5],
            [4.5]])
     >>> time_series = [[1, 2, 3, 4], [1, 2, 3, 4, 5]]
-    >>> dtw_barycenter_averaging(time_series, max_iter=5)
+    >>> dtw_barycenter_averaging_petitjean(time_series, max_iter=5)
     array([[1. ],
            [2. ],
            [3. ],
            [4. ],
            [4.5]])
-    >>> dtw_barycenter_averaging(time_series, max_iter=5,
+    >>> dtw_barycenter_averaging_petitjean(time_series, max_iter=5,
     ...                          metric_params={"itakura_max_slope": 2})
     array([[1. ],
            [2. ],
            [3. ],
            [3.5],
            [4.5]])
-    >>> dtw_barycenter_averaging(time_series, max_iter=5, barycenter_size=3)
+    >>> dtw_barycenter_averaging_petitjean(time_series, max_iter=5,
+    ...                                    barycenter_size=3)
     array([[1.5       ],
            [3.        ],
            [4.33333333]])
@@ -298,7 +300,7 @@ def _mm_valence_warping(list_p_k, barycenter_size, weights):
 
     .. [1] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
        for Averaging in Dynamic Time Warping Spaces.
-       TODO: where was it published?
+       Pattern Recognition, 74, 340-358.
     """
     diag_sum_v_k = numpy.zeros((barycenter_size, ))
     list_w_k = []
@@ -339,7 +341,7 @@ def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
 
     .. [1] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
        for Averaging in Dynamic Time Warping Spaces.
-       TODO: where was it published?
+       Pattern Recognition, 74, 340-358.
     """
     d = X.shape[2]
     barycenter_size = diag_sum_v_k.shape[0]
@@ -350,10 +352,10 @@ def _mm_update_barycenter(X, diag_sum_v_k, list_w_k):
     return barycenter
 
 
-def dtw_barycenter_averaging_mm(X, barycenter_size=None, init_barycenter=None,
-                                max_iter=30, tol=1e-5, weights=None,
-                                metric_params=None,
-                                verbose=False):
+def dtw_barycenter_averaging(X, barycenter_size=None, init_barycenter=None,
+                             max_iter=30, tol=1e-5, weights=None,
+                             metric_params=None,
+                             verbose=False):
     """DTW Barycenter Averaging (DBA) method.
 
     DBA was originally presented in [1]_.
@@ -404,26 +406,26 @@ def dtw_barycenter_averaging_mm(X, barycenter_size=None, init_barycenter=None,
     Examples
     --------
     >>> time_series = [[1, 2, 3, 4], [1, 2, 4, 5]]
-    >>> dtw_barycenter_averaging_mm(time_series, max_iter=5)
+    >>> dtw_barycenter_averaging(time_series, max_iter=5)
     array([[1. ],
            [2. ],
            [3.5],
            [4.5]])
     >>> time_series = [[1, 2, 3, 4], [1, 2, 3, 4, 5]]
-    >>> dtw_barycenter_averaging_mm(time_series, max_iter=5)
+    >>> dtw_barycenter_averaging(time_series, max_iter=5)
     array([[1. ],
            [2. ],
            [3. ],
            [4. ],
            [4.5]])
-    >>> dtw_barycenter_averaging_mm(time_series, max_iter=5,
-    ...                             metric_params={"itakura_max_slope": 2})
+    >>> dtw_barycenter_averaging(time_series, max_iter=5,
+    ...                          metric_params={"itakura_max_slope": 2})
     array([[1. ],
            [2. ],
            [3. ],
            [3.5],
            [4.5]])
-    >>> dtw_barycenter_averaging_mm(time_series, max_iter=5, barycenter_size=3)
+    >>> dtw_barycenter_averaging(time_series, max_iter=5, barycenter_size=3)
     array([[1.5       ],
            [3.        ],
            [4.33333333]])

--- a/tslearn/docs/examples/plot_barycenters.py
+++ b/tslearn/docs/examples/plot_barycenters.py
@@ -13,7 +13,8 @@ import numpy
 import matplotlib.pyplot as plt
 
 from tslearn.barycenters import euclidean_barycenter, \
-    dtw_barycenter_averaging, softdtw_barycenter
+    dtw_barycenter_averaging, dtw_barycenter_averaging_subgradient, \
+    softdtw_barycenter
 from tslearn.datasets import CachedDatasets
 
 numpy.random.seed(0)
@@ -21,20 +22,27 @@ X_train, y_train, X_test, y_test = CachedDatasets().load_dataset("Trace")
 X = X_train[y_train == 2]
 
 plt.figure()
-plt.subplot(3, 1, 1)
+plt.subplot(4, 1, 1)
 for ts in X:
     plt.plot(ts.ravel(), "k-", alpha=.2)
 plt.plot(euclidean_barycenter(X).ravel(), "r-", linewidth=2)
 plt.title("Euclidean barycenter")
 
-plt.subplot(3, 1, 2)
+plt.subplot(4, 1, 2)
 dba_bar = dtw_barycenter_averaging(X, max_iter=100, verbose=False)
 for ts in X:
     plt.plot(ts.ravel(), "k-", alpha=.2)
 plt.plot(dba_bar.ravel(), "r-", linewidth=2)
-plt.title("DBA")
+plt.title("DBA (vectorized version of Petitjean's EM)")
 
-plt.subplot(3, 1, 3)
+plt.subplot(4, 1, 3)
+dba_bar = dtw_barycenter_averaging_subgradient(X, max_iter=100, verbose=False)
+for ts in X:
+    plt.plot(ts.ravel(), "k-", alpha=.2)
+plt.plot(dba_bar.ravel(), "r-", linewidth=2)
+plt.title("DBA (subgradient descent approach)")
+
+plt.subplot(4, 1, 4)
 sdtw_bar = softdtw_barycenter(X, gamma=1., max_iter=100)
 for ts in X:
     plt.plot(ts.ravel(), "k-", alpha=.2)

--- a/tslearn/docs/gen_modules/tslearn.barycenters.rst
+++ b/tslearn/docs/gen_modules/tslearn.barycenters.rst
@@ -13,6 +13,5 @@ tslearn.barycenters
 
       euclidean_barycenter
       dtw_barycenter_averaging
-      dtw_barycenter_averaging_mm
       softdtw_barycenter
 

--- a/tslearn/docs/gen_modules/tslearn.barycenters.rst
+++ b/tslearn/docs/gen_modules/tslearn.barycenters.rst
@@ -13,5 +13,6 @@ tslearn.barycenters
 
       euclidean_barycenter
       dtw_barycenter_averaging
+      dtw_barycenter_averaging_subgradient
       softdtw_barycenter
 

--- a/tslearn/docs/gen_modules/tslearn.barycenters.rst
+++ b/tslearn/docs/gen_modules/tslearn.barycenters.rst
@@ -13,5 +13,6 @@ tslearn.barycenters
 
       euclidean_barycenter
       dtw_barycenter_averaging
+      dtw_barycenter_averaging_mm
       softdtw_barycenter
 

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -727,7 +727,7 @@ def cdist_dtw(dataset1, dataset2=None, global_constraint=None,
         Above 50, the output is sent to stdout. 
         The frequency of the messages increases with the verbosity level. 
         If it more than 10, all iterations are reported.
-        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`_  
+        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`__
         for more details.
 
     Returns
@@ -926,7 +926,7 @@ def cdist_gak(dataset1, dataset2=None, sigma=1., n_jobs=None, verbose=0):
         Above 50, the output is sent to stdout. 
         The frequency of the messages increases with the verbosity level. 
         If it more than 10, all iterations are reported.
-        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`_  
+        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`__
         for more details.
 
     Returns

--- a/tslearn/neighbors.py
+++ b/tslearn/neighbors.py
@@ -138,7 +138,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors):
         parallelization.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See scikit-learns'
-        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`__
         for more details.
 
     Examples
@@ -159,7 +159,7 @@ class KNeighborsTimeSeries(KNeighborsTimeSeriesMixin, NearestNeighbors):
     array([[2, 1],
            [2, 0],
            [0, 1]])
-    """
+    """  # noqa: E501
     def __init__(self, n_neighbors=5, metric="dtw", metric_params=None,
                  n_jobs=None, verbose=0):
         NearestNeighbors.__init__(self,
@@ -249,7 +249,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         parallelization.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See scikit-learns'
-        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`__
         for more details.
 
     verbose : int, optional (default=0)
@@ -257,7 +257,7 @@ class KNeighborsTimeSeriesClassifier(KNeighborsTimeSeriesMixin,
         Above 50, the output is sent to stdout. 
         The frequency of the messages increases with the verbosity level. 
         If it more than 10, all iterations are reported.
-        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`_ 
+        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`__
         for more details.
 
     Examples
@@ -468,7 +468,7 @@ class KNeighborsTimeSeriesRegressor(KNeighborsTimeSeriesMixin,
         parallelization.
         ``None`` means 1 unless in a :obj:`joblib.parallel_backend` context.
         ``-1`` means using all processors. See scikit-learns'
-        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`_
+        `Glossary <https://scikit-learn.org/stable/glossary.html#term-n-jobs>`__
         for more details.
 
     verbose : int, optional (default=0)
@@ -476,7 +476,7 @@ class KNeighborsTimeSeriesRegressor(KNeighborsTimeSeriesMixin,
         Above 50, the output is sent to stdout. 
         The frequency of the messages increases with the verbosity level. 
         If it more than 10, all iterations are reported.
-        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`_  
+        `Glossary <https://joblib.readthedocs.io/en/latest/parallel.html#parallel-reference-documentation>`__
         for more details.
 
     Examples

--- a/tslearn/tests/test_barycenters.py
+++ b/tslearn/tests/test_barycenters.py
@@ -59,6 +59,14 @@ def test_dba():
                     [-0.32249566, 0.09109832, 0.55489214]])
     np.testing.assert_allclose(dba_bar, ref, atol=1e-6)
 
+    dba_bar = tslearn.barycenters.dtw_barycenter_averaging_petitjean(
+        time_series,
+        max_iter=5)
+    dba_bar_mm = tslearn.barycenters.dtw_barycenter_averaging(
+        time_series,
+        max_iter=5)
+    np.testing.assert_allclose(dba_bar, dba_bar_mm)
+
     weights = rng.rand(n)
     dba_bar = tslearn.barycenters.dtw_barycenter_averaging_petitjean(
         time_series,

--- a/tslearn/tests/test_barycenters.py
+++ b/tslearn/tests/test_barycenters.py
@@ -38,13 +38,15 @@ def test_dba():
 
     # Equal length, 0 iterations -> Euclidean
     euc_bar = tslearn.barycenters.euclidean_barycenter(time_series)
-    dba_bar = tslearn.barycenters.dtw_barycenter_averaging(time_series,
-                                                           max_iter=0)
+    dba_bar = tslearn.barycenters.dtw_barycenter_averaging_petitjean(
+        time_series,
+        max_iter=0)
     np.testing.assert_allclose(euc_bar, dba_bar)
 
     # Equal length, >0 iterations
-    dba_bar = tslearn.barycenters.dtw_barycenter_averaging(time_series,
-                                                           max_iter=5)
+    dba_bar = tslearn.barycenters.dtw_barycenter_averaging_petitjean(
+        time_series,
+        max_iter=5)
     ref = np.array([[0.33447722, 0.0418787, -0.03953774],
                     [-0.75757987, -0.26841384, -0.22418874],
                     [-0.0473153, 0.41030073, 0.06069343],
@@ -56,6 +58,17 @@ def test_dba():
                     [0.67493146, -0.37714421, 0.16604165],
                     [-0.32249566, 0.09109832, 0.55489214]])
     np.testing.assert_allclose(dba_bar, ref, atol=1e-6)
+
+    weights = rng.rand(n)
+    dba_bar = tslearn.barycenters.dtw_barycenter_averaging_petitjean(
+        time_series,
+        weights=weights,
+        max_iter=5)
+    dba_bar_mm = tslearn.barycenters.dtw_barycenter_averaging(
+        time_series,
+        weights=weights,
+        max_iter=5)
+    np.testing.assert_allclose(dba_bar, dba_bar_mm)
 
 
 def test_softdtw_barycenter():


### PR DESCRIPTION
As suggested (loooong ago) in #45 , there exist a vectorized form of the DBA algorithm. I have implemented it, and I like it because:

* it it strictly equivalent to DBA
* the code is more readable imho
* it is a bit faster:

```python
import numpy as np
import time

from tslearn.barycenters import dtw_barycenter_averaging_mm, dtw_barycenter_averaging


__author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'


n, sz, d = 500, 200, 10
data = np.random.randn(n, sz, d)

t0 = time.time()
bar = dtw_barycenter_averaging_mm(X=data)
print("Elapsed time for MM version: %f" % (time.time() - t0))

t0 = time.time()
bar = dtw_barycenter_averaging(X=data)
print("Elapsed time for DBA version: %f" % (time.time() - t0))
```

gives:

```
Elapsed time for MM version: 25.453088
Elapsed time for DBA version: 37.681433
```

on my machine.

In the end, I am not so sure about keeping original DBA code since it seems more likely to be/get buggy than this one.