### PR TITLE
Add pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,13 @@ If you use `tslearn` in a scientific publication, we would appreciate citations:
 
 ```bibtex
 @misc{tslearn,
- title={tslearn: A machine learning toolkit dedicated to time-series data},
- author={Tavenard, Romain and Faouzi, Johann and Vandewiele, Gilles},
- year={2017},
- note={\url{https://github.com/rtavenar/tslearn}}
+      title={tslearn: A machine learning toolkit dedicated to time-series
+             data},
+      author={Romain Tavenard and Johann Faouzi and Gilles Vandewiele and
+              Felix Divo and Guillaume Androz and Chester Holtz and Marie
+              Payne and Roman Yurchak and Marc Ru{\ss}wurm and Kushal
+              Kolar and Eli Woods},
+      year={2017},
+      note={\url{https://github.com/rtavenar/tslearn}}
 }
 ```


### PR DESCRIPTION
In the past there have been some issues raised on not being able to easilly install `tslearn` via `pip` (see e.g. #84 and #132). Even though these issues are closed there is an easy fix for this given by [PEP-518](https://www.python.org/dev/peps/pep-0518/). This PR adds a `pyproject.toml` file which makes it possible to install `tslearn` from source by simply using `pip`.

I'm curious to hear any feedback on the idea of including this.