### PR TITLE
Disregard NaNs in TimeSeriesScalerMeanVariance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 - pip install pytest
 - if [[ "$NUMBA_DISABLE_JIT" == 1 ]]; then pip install coverage==4.3 "pytest-cov<2.6"; fi
 - pip install argparse
-- pip install codeclimate-test-reporter
+- pip install codeclimate-test-reporter codecov
 - rm -f tslearn/*.c
 - python setup.py build_ext --inplace
 script:
@@ -61,7 +61,8 @@ script:
   fi
 
 after_success:
-- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then codeclimate-test-reporter fi
+- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then codeclimate-test-reporter; fi
+- if [ "$NUMBA_DISABLE_JIT" == 1 ]; then codecov; fi
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 Changelogs for this project are recorded in this file since v0.2.0.
 
+## [v0.2.4]
+
+### Fixed
+
+* The `tests` subdirectory is now made a python package and hence included in 
+wheels
+
 ## [v0.2.2]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 Changelogs for this project are recorded in this file since v0.2.0.
 
+## [v0.2.2]
+
+### Fixed
+
+* The way version number is retrieved in `setup.py` was not working properly 
+on Python 3.4 (and made the install script fail), switched back to the previous
+version
+
 ## [v0.2.1]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,32 +43,24 @@ Using `pip` should also work fine:
 pip install tslearn
 ```
 
+In this case, you should have `numpy`, `cython` and C++ build tools available
+at build time.
+
 ## Using latest github-hosted version
 
-If you want to get `tslearn`'s latest version, you can refer to the repository hosted at github:
+If you want to get `tslearn`'s latest version, you can refer to the repository 
+hosted at github:
 ```bash
 pip install git+https://github.com/rtavenar/tslearn.git
 ```
 
-## Troubleshooting
-
-It seems on some platforms `Cython` dependency does not install properly.
-If you experiment such an issue, try installing it with the following command:
-
-```bash
-pip install cython
-```
-
-or (depending on your preferred python package manager):
-```bash
-conda install -c anaconda cython
-```
-
-before you start installing `tslearn`.
+In this case, you should have `numpy`, `cython` and C++ build tools available
+at build time.
 
 # Documentation and API reference
 
-The documentation, including a gallery of examples, is hosted at [readthedocs](http://tslearn.readthedocs.io/en/latest/index.html).
+The documentation, including a gallery of examples, is hosted at 
+[readthedocs](http://tslearn.readthedocs.io/en/latest/index.html).
 
 # Already available
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 [![PyPI version](https://badge.fury.io/py/tslearn.svg)](https://badge.fury.io/py/tslearn)
 [![Documentation Status](https://readthedocs.org/projects/tslearn/badge/?version=latest)](http://tslearn.readthedocs.io/en/latest/?badge=latest)
 [![Build Status](https://travis-ci.org/rtavenar/tslearn.svg?branch=master)](https://travis-ci.org/rtavenar/tslearn)
-[![Code Climate](https://codeclimate.com/github/rtavenar/tslearn/badges/gpa.svg)](https://codeclimate.com/github/rtavenar/tslearn)
-[![Test Coverage](https://codeclimate.com/github/rtavenar/tslearn/badges/coverage.svg)](https://codeclimate.com/github/rtavenar/tslearn/coverage)
+[![Codecov](https://codecov.io/gh/rtavenar/tslearn/branch/master/graph/badge.svg)](https://codecov.io/gh/rtavenar/tslearn)
 [![Downloads](https://pepy.tech/badge/tslearn)](https://pepy.tech/project/tslearn)
 
 `tslearn` is a Python package that provides machine learning tools for the analysis of time series.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ numba
 scipy
 scikit-learn
 joblib>=0.12
-tensorflow
+tensorflow<2
 keras

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ numba
 scipy
 scikit-learn
 joblib>=0.12
-numba
 tensorflow
 keras

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -8,7 +8,7 @@ ipykernel
 nbsphinx
 sphinx-gallery
 pillow
-tensorflow
+tensorflow<=1.9
 keras
 Pygments
 numba

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -8,7 +8,7 @@ ipykernel
 nbsphinx
 sphinx-gallery
 pillow
-tensorflow<=1.9
+tensorflow<2
 keras
 Pygments
 numba

--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,17 @@ import re
 import os
 from Cython.Build import cythonize
 
-# dirty but working (from POT)
-__version__ = re.search(
-    r'__version__\s*=\s*[\'"]([^\'"]*)[\'"]',  # It excludes inline comment too
-    open('tslearn/__init__.py').read()).group(1)
-# The beautiful part is, I don't even need to check exceptions here.
-# If something messes up, let the build process fail noisy, BEFORE my release!
-
 # thanks Pipy for handling markdown now
 ROOT = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(ROOT, 'README.md'), encoding="utf-8") as f:
     README = f.read()
+
+# We can actually import a restricted version of tslearn that
+# does not need the compiled code
+import tslearn
+
+VERSION = tslearn.__version__
 
 setup(
     name="tslearn",
@@ -30,7 +29,7 @@ setup(
     install_requires=['numpy', 'scipy', 'scikit-learn', 'Cython', 'numba'],
     extras_require={'tests': ['pytest']},
     ext_modules=cythonize("tslearn/*.pyx", include_path=[numpy.get_include()]),
-    version=__version__,
+    version=VERSION,
     url="http://tslearn.readthedocs.io/",
     author="Romain Tavenard",
     author_email="romain.tavenard@univ-rennes2.fr"

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import setup
 from codecs import open
 import numpy
-import re
 import os
 from Cython.Build import cythonize
 
@@ -26,7 +25,8 @@ setup(
     packages=['tslearn'],
     package_data={"tslearn": [".cached_datasets/Trace.npz"]},
     data_files=[("", ["LICENSE"])],
-    install_requires=['numpy', 'scipy', 'scikit-learn', 'Cython', 'numba'],
+    install_requires=['numpy', 'scipy', 'scikit-learn', 'Cython', 'numba',
+                      'joblib'],
     extras_require={'tests': ['pytest']},
     ext_modules=cythonize("tslearn/*.pyx", include_path=[numpy.get_include()]),
     version=VERSION,

--- a/tslearn/__init__.py
+++ b/tslearn/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __bibtex__ = r"""@misc{tslearn,
  title={tslearn: A machine learning toolkit dedicated to time-series data},
  author={Tavenard, Romain and Faouzi, Johann and Vandewiele, Gilles},

--- a/tslearn/__init__.py
+++ b/tslearn/__init__.py
@@ -1,7 +1,7 @@
 import os
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __bibtex__ = r"""@misc{tslearn,
  title={tslearn: A machine learning toolkit dedicated to time-series data},
  author={Tavenard, Romain and Faouzi, Johann and Vandewiele, Gilles},

--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -205,7 +205,7 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
         del metric_params_["n_jobs"]
     if metric == "precomputed":
         sklearn_X = X
-    elif metric == "dtw":
+    elif metric == "dtw" or metric is None:
         sklearn_X = cdist_dtw(X, n_jobs=n_jobs, **metric_params_)
     elif metric == "softdtw":
         sklearn_X = cdist_soft_dtw_normalized(X, **metric_params_)
@@ -217,8 +217,6 @@ def silhouette_score(X, labels, metric=None, sample_size=None,
         X_ = to_time_series_dataset(X)
         n, sz, d = X_.shape
         sklearn_X = X_.reshape((n, -1))
-        if metric is None:
-            metric = dtw
 
         def sklearn_metric(x, y):
             return metric(to_time_series(x.reshape((sz, d)),

--- a/tslearn/docs/_static/custom.css
+++ b/tslearn/docs/_static/custom.css
@@ -2,21 +2,21 @@ code {
     color: #055781;
 }
 
-longtable tbody tr:nth-child(even) {
+table.longtable tbody tr:nth-child(even) {
     background-color: #FDFDFD;
 
 }
-longtable tbody tr:nth-child(odd) {
+table.longtable tbody tr:nth-child(odd) {
     background-color: #F0F7FA;
 }
 
-longtable tbody tr {
+table.longtable tbody tr {
     border-style: solid none solid none;
     border-width: 1px 0 1px 0;
     border-color: #ddd;
 }
 
-longtable tbody td {
+table.longtable tbody td {
     border-color: #ddd;
 }
 

--- a/tslearn/docs/_static/custom.css
+++ b/tslearn/docs/_static/custom.css
@@ -2,21 +2,21 @@ code {
     color: #055781;
 }
 
-tbody tr:nth-child(even) {
+longtable tbody tr:nth-child(even) {
     background-color: #FDFDFD;
 
 }
-tbody tr:nth-child(odd) {
+longtable tbody tr:nth-child(odd) {
     background-color: #F0F7FA;
 }
 
-tbody tr {
+longtable tbody tr {
     border-style: solid none solid none;
     border-width: 1px 0 1px 0;
     border-color: #ddd;
 }
 
-tbody td {
+longtable tbody td {
     border-color: #ddd;
 }
 

--- a/tslearn/docs/index.rst
+++ b/tslearn/docs/index.rst
@@ -17,10 +17,6 @@ If you plan to use the ``shapelets`` module from ``tslearn``, ``keras`` and
 Installation
 ------------
 
-Pre-requisites 
-``````````````
-C++ build tools should be available to perform installation.
-
 Using conda
 ```````````
 

--- a/tslearn/docs/index.rst
+++ b/tslearn/docs/index.rst
@@ -6,10 +6,13 @@
 ``tslearn``'s documentation
 ===========================
 
-``tslearn`` is a Python package that provides machine learning tools for the analysis of time series.
-This package builds on (and hence depends on) ``scikit-learn``, ``numpy`` and ``scipy`` libraries.
+``tslearn`` is a Python package that provides machine learning tools for the
+analysis of time series.
+This package builds on (and hence depends on) ``scikit-learn``, ``numpy`` and
+``scipy`` libraries.
 
-If you plan to use the ``shapelets`` module from ``tslearn``, ``keras`` and ``tensorflow`` should also be installed.
+If you plan to use the ``shapelets`` module from ``tslearn``, ``keras`` and
+``tensorflow`` should also be installed.
 
 Installation
 ------------
@@ -37,35 +40,23 @@ Using ``pip`` should also work fine:
     pip install tslearn
 
 
+In this case, you should have ``numpy``, ``cython`` and C++ build tools
+available at build time.
+
 Using latest github-hosted version
 ``````````````````````````````````
 
-If you want to get ``tslearn``'s latest version, you can refer to the repository hosted at github:
+If you want to get ``tslearn``'s latest version, you can refer to the
+repository hosted at github:
 
 .. code-block:: bash
   
     pip install git+https://github.com/rtavenar/tslearn.git
 
 
-Troubleshooting
-```````````````
 
-It seems on some platforms ``Cython`` dependency does not install properly.
-If you experiment such an issue, try installing it with the following command:
-
-.. code-block:: bash
-
-    pip install cython
-
-
-or (depending on your preferred python package manager):
-
-.. code-block:: bash
-
-    conda install -c anaconda cython
-
-
-before you start installing ``tslearn``.
+In this case, you should have ``numpy``, ``cython`` and C++ build tools
+available at build time.
 
 
 Navigation

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -263,11 +263,13 @@ def dtw(s1, s2, global_constraint=None, sakoe_chiba_radius=1,
     (possibly multidimensional) time series and return it.
 
     DTW is computed as the Euclidean distance between aligned time series,
-    i.e., if :math:`P` is the alignment path:
+    i.e., if :math:`P` is the optimal alignment path:
 
     .. math::
 
-        DTW(X, Y) = \sqrt{\sum_{(i, j) \in P} (X_{i} - Y_{j})^2}
+        DTW(X, Y) = \sqrt{\sum_{(i, j) \in P} \|X_{i} - Y_{j}\|^2}
+
+    Note that this formula is still valid for the multivariate case.
 
     It is not required that both time series share the same size, but they must
     be the same dimension. DTW was originally presented in [1]_.

--- a/tslearn/metrics.py
+++ b/tslearn/metrics.py
@@ -1144,7 +1144,7 @@ def lb_keogh(ts_query, ts_candidate=None, radius=1, envelope_candidate=None):
         Query time-series to compare to the envelope of the candidate.
     ts_candidate : array-like or None (default: None)
         Candidate time-series. None means the envelope is provided via
-        `envelope_query` parameter and hence does not
+        `envelope_candidate` parameter and hence does not
         need to be computed again.
     radius : int (default: 1)
         Radius to be used for the envelope generation (the envelope at time

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -231,8 +231,8 @@ class TimeSeriesScalerMeanVariance(TransformerMixin):
             Rescaled time series dataset
         """
         X_ = to_time_series_dataset(X)
-        mean_t = numpy.mean(X_, axis=1)[:, numpy.newaxis, :]
-        std_t = numpy.std(X_, axis=1)[:, numpy.newaxis, :]
+        mean_t = numpy.nanmean(X_, axis=1)[:, numpy.newaxis, :]
+        std_t = numpy.nanstd(X_, axis=1)[:, numpy.newaxis, :]
         std_t[std_t == 0.] = 1.
 
         X_ = (X_ - mean_t) * self.std_ / std_t + self.mu_

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -103,11 +103,17 @@ class TimeSeriesScalerMinMax(TransformerMixin):
     -----
         This method requires a dataset of equal-sized time series.
 
+        NaNs within a time series are ignored when calculating min and max.
+
     Examples
     --------
     >>> TimeSeriesScalerMinMax(value_range=(1., 2.)).fit_transform([[0, 3, 6]])
     array([[[1. ],
             [1.5],
+            [2. ]]])
+    >>> TimeSeriesScalerMinMax(value_range=(1., 2.)).fit_transform([[numpy.nan, 3, 6]])
+    array([[[nan],
+            [1. ],
             [2. ]]])
     """
     def __init__(self, value_range=(0., 1.), min=None, max=None):
@@ -188,6 +194,8 @@ class TimeSeriesScalerMeanVariance(TransformerMixin):
     -----
         This method requires a dataset of equal-sized time series.
 
+        NaNs within a time series are ignored when calculating mu and std.
+
     Examples
     --------
     >>> TimeSeriesScalerMeanVariance(mu=0.,
@@ -195,6 +203,11 @@ class TimeSeriesScalerMeanVariance(TransformerMixin):
     array([[[-1.22474487],
             [ 0.        ],
             [ 1.22474487]]])
+    >>> TimeSeriesScalerMeanVariance(mu=0.,
+    ...                              std=1.).fit_transform([[numpy.nan, 3, 6]])
+    array([[[nan],
+            [-1.],
+            [ 1.]]])
     """
     def __init__(self, mu=0., std=1.):
         self.mu_ = mu

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -164,8 +164,8 @@ class TimeSeriesScalerMinMax(TransformerMixin):
                              " than maximum. Got %s." % str(self.value_range))
 
         X_ = to_time_series_dataset(X)
-        min_t = numpy.min(X_, axis=1)[:, numpy.newaxis, :]
-        max_t = numpy.max(X_, axis=1)[:, numpy.newaxis, :]
+        min_t = numpy.nanmin(X_, axis=1)[:, numpy.newaxis, :]
+        max_t = numpy.nanmax(X_, axis=1)[:, numpy.newaxis, :]
         range_t = max_t - min_t
         nomin = (X_ - min_t) * (self.value_range[1] - self.value_range[0])
         X_ = nomin / range_t + self.value_range[0]

--- a/tslearn/shapelets.py
+++ b/tslearn/shapelets.py
@@ -319,15 +319,15 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     @property
     def _n_shapelet_sizes(self):
-        return len(self.n_shapelets_per_size_)
+        return len(self.n_shapelets_per_size)
 
     @property
     def shapelets_(self):
-        total_n_shp = sum(self.n_shapelets_per_size_.values())
+        total_n_shp = sum(self.n_shapelets_per_size.values())
         shapelets = numpy.empty((total_n_shp, ), dtype=object)
         idx = 0
-        for i, shp_sz in enumerate(sorted(self.n_shapelets_per_size_.keys())):
-            n_shp = self.n_shapelets_per_size_[shp_sz]
+        for i, shp_sz in enumerate(sorted(self.n_shapelets_per_size.keys())):
+            n_shp = self.n_shapelets_per_size[shp_sz]
             for idx_shp in range(idx, idx + n_shp):
                 shapelets[idx_shp] = numpy.zeros((shp_sz, self.d_))
             for di in range(self.d_):
@@ -340,12 +340,25 @@ class ShapeletModel(BaseEstimator, ClassifierMixin, TransformerMixin):
 
     @property
     def shapelets_as_time_series_(self):
-        total_n_shp = sum(self.n_shapelets_per_size_.values())
-        shp_sz = max(self.n_shapelets_per_size_.keys())
+        """Set of time-series shapelets formatted as a ``tslearn`` time series
+        dataset.
+
+        Examples
+        --------
+        >>> from tslearn.generators import random_walk_blobs
+        >>> X, y = random_walk_blobs(n_ts_per_blob=10, sz=256, d=1, n_blobs=3)
+        >>> model = ShapeletModel(n_shapelets_per_size={3: 2, 4: 1},
+        ...                       max_iter=1)
+        >>> _ = model.fit(X, y)
+        >>> model.shapelets_as_time_series_.shape
+        (3, 4, 1)
+        """
+        total_n_shp = sum(self.n_shapelets_per_size.values())
+        shp_sz = max(self.n_shapelets_per_size.keys())
         non_formatted_shapelets = self.shapelets_
         d = non_formatted_shapelets[0].shape[1]
         shapelets = numpy.zeros((total_n_shp, shp_sz, d)) + numpy.nan
-        for i in range(self._n_shapelet_sizes):
+        for i in range(total_n_shp):
             sz = non_formatted_shapelets[i].shape[0]
             shapelets[i, :sz, :] = non_formatted_shapelets[i]
         return shapelets

--- a/tslearn/shapelets.py
+++ b/tslearn/shapelets.py
@@ -17,10 +17,7 @@ from keras.initializers import Initializer
 import keras.backend as K
 from keras.engine import InputSpec
 import numpy
-try:
-    from tensorflow import set_random_seed
-except ImportError:  # TF2
-    from tensorflow.compat.v1 import set_random_seed
+from tensorflow import set_random_seed
 
 import warnings
 

--- a/tslearn/shapelets.py
+++ b/tslearn/shapelets.py
@@ -17,7 +17,10 @@ from keras.initializers import Initializer
 import keras.backend as K
 from keras.engine import InputSpec
 import numpy
-from tensorflow import set_random_seed
+try:
+    from tensorflow import set_random_seed
+except ImportError:  # TF2
+    from tensorflow.compat.v1 import set_random_seed
 
 import warnings
 

--- a/tslearn/tests/test_neighbors.py
+++ b/tslearn/tests/test_neighbors.py
@@ -1,0 +1,42 @@
+import numpy as np
+from tslearn.neighbors import KNeighborsTimeSeriesClassifier
+
+__author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
+
+
+def test_constrained_paths():
+    n, sz, d = 15, 10, 3
+    rng = np.random.RandomState(0)
+    X = rng.randn(n, sz, d)
+    y = rng.randint(low=0, high=3, size=n)
+
+    model_euc = KNeighborsTimeSeriesClassifier(n_neighbors=3,
+                                               metric="euclidean")
+    y_pred_euc = model_euc.fit(X, y).predict(X)
+    model_dtw_sakoe = KNeighborsTimeSeriesClassifier(
+        n_neighbors=3,
+        metric="dtw",
+        metric_params={
+            "global_constraint": "sakoe_chiba",
+            "sakoe_chiba_radius":0
+        }
+    )
+    y_pred_sakoe = model_dtw_sakoe.fit(X, y).predict(X)
+    np.testing.assert_equal(y_pred_euc, y_pred_sakoe)
+
+    model_softdtw = KNeighborsTimeSeriesClassifier(
+        n_neighbors=3,
+        metric="softdtw",
+        metric_params={
+            "gamma": 1e-6
+        }
+    )
+    y_pred_softdtw = model_softdtw.fit(X, y).predict(X)
+
+    model_dtw = KNeighborsTimeSeriesClassifier(
+            n_neighbors=3,
+            metric="dtw"
+    )
+    y_pred_dtw = model_dtw.fit(X, y).predict(X)
+
+    np.testing.assert_equal(y_pred_dtw, y_pred_softdtw)

--- a/tslearn/tests/test_shapelets.py
+++ b/tslearn/tests/test_shapelets.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from tslearn.shapelets import ShapeletModel, SerializableShapeletModel
+from tslearn.utils import to_time_series
+import tslearn
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
@@ -26,6 +28,14 @@ def test_shapelets():
 
     from sklearn.model_selection import cross_validate
     cross_validate(clf, time_series, y, cv=2)
+
+    model = ShapeletModel(n_shapelets_per_size={3: 2, 4: 1},
+                          max_iter = 1)
+    model.fit(time_series, y)
+    for shp, shp_bis in zip(model.shapelets_,
+                            model.shapelets_as_time_series_):
+        np.testing.assert_allclose(shp,
+                                   to_time_series(shp_bis, remove_nans=True))
 
 
 def test_serializable_shapelets():


### PR DESCRIPTION
If a time series with any `NaN` values is passed to `TimeSeriesScalerMeanVariance.fit_transform()` the transformed time series returns as all `NaN`

E.g:
```
In [1]: from tslearn.preprocessing import TimeSeriesScalerMeanVariance                                                                

In [2]: from numpy import nan                                                                                                         

In [3]: TimeSeriesScalerMeanVariance().fit_transform([0, nan, 6])                                                                     
Out[3]: 
array([[[nan],
        [nan],
        [nan]]])
```

This could be fixed by using `numpy.nanmean()` and `numpy.nanstd()` in `TimeSeriesScalerMeanVariance.transform` instead of the current implementation. This also makes tslearn in line with sklearn in terms of NaN's and preprocessing: https://github.com/scikit-learn/scikit-learn/issues/10404 