### PR TITLE
[MRG] Disregard NaNs in preprocessing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ local optima using a parameter `n_init` set to 1 by default
 module have changed their names to `load_time_series_txt` and 
 `save_time_series_txt`. Old names can still be used but considered deprecated
  and removed from the public API documentation for the sake of harmonization
+ * `TimeSeriesScalerMeanVariance` and `TimeSeriesScalerMinMax` now ignore any
+ NaNs when calling their respective `transform` methods in order to better
+ mirror scikit-learn's handling of missing data in preprocessing.
 
 ### Added
 

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -103,11 +103,17 @@ class TimeSeriesScalerMinMax(TransformerMixin):
     -----
         This method requires a dataset of equal-sized time series.
 
+        NaNs within a time series are ignored when calculating min and max.
+
     Examples
     --------
     >>> TimeSeriesScalerMinMax(value_range=(1., 2.)).fit_transform([[0, 3, 6]])
     array([[[1. ],
             [1.5],
+            [2. ]]])
+    >>> TimeSeriesScalerMinMax(value_range=(1., 2.)).fit_transform([[numpy.nan, 3, 6]])
+    array([[[nan],
+            [1. ],
             [2. ]]])
     """
     def __init__(self, value_range=(0., 1.), min=None, max=None):
@@ -164,8 +170,8 @@ class TimeSeriesScalerMinMax(TransformerMixin):
                              " than maximum. Got %s." % str(self.value_range))
 
         X_ = to_time_series_dataset(X)
-        min_t = numpy.min(X_, axis=1)[:, numpy.newaxis, :]
-        max_t = numpy.max(X_, axis=1)[:, numpy.newaxis, :]
+        min_t = numpy.nanmin(X_, axis=1)[:, numpy.newaxis, :]
+        max_t = numpy.nanmax(X_, axis=1)[:, numpy.newaxis, :]
         range_t = max_t - min_t
         nomin = (X_ - min_t) * (self.value_range[1] - self.value_range[0])
         X_ = nomin / range_t + self.value_range[0]
@@ -188,6 +194,8 @@ class TimeSeriesScalerMeanVariance(TransformerMixin):
     -----
         This method requires a dataset of equal-sized time series.
 
+        NaNs within a time series are ignored when calculating mu and std.
+
     Examples
     --------
     >>> TimeSeriesScalerMeanVariance(mu=0.,
@@ -195,6 +203,11 @@ class TimeSeriesScalerMeanVariance(TransformerMixin):
     array([[[-1.22474487],
             [ 0.        ],
             [ 1.22474487]]])
+    >>> TimeSeriesScalerMeanVariance(mu=0.,
+    ...                              std=1.).fit_transform([[numpy.nan, 3, 6]])
+    array([[[nan],
+            [-1.],
+            [ 1.]]])
     """
     def __init__(self, mu=0., std=1.):
         self.mu_ = mu
@@ -231,8 +244,8 @@ class TimeSeriesScalerMeanVariance(TransformerMixin):
             Rescaled time series dataset
         """
         X_ = to_time_series_dataset(X)
-        mean_t = numpy.mean(X_, axis=1)[:, numpy.newaxis, :]
-        std_t = numpy.std(X_, axis=1)[:, numpy.newaxis, :]
+        mean_t = numpy.nanmean(X_, axis=1)[:, numpy.newaxis, :]
+        std_t = numpy.nanstd(X_, axis=1)[:, numpy.newaxis, :]
         std_t[std_t == 0.] = 1.
 
         X_ = (X_ - mean_t) * self.std_ / std_t + self.mu_

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -111,7 +111,9 @@ class TimeSeriesScalerMinMax(TransformerMixin):
     array([[[1. ],
             [1.5],
             [2. ]]])
-    >>> TimeSeriesScalerMinMax(value_range=(1., 2.)).fit_transform([[numpy.nan, 3, 6]])
+    >>> TimeSeriesScalerMinMax(value_range=(1., 2.)).fit_transform(
+    ...     [[numpy.nan, 3, 6]]
+    ... )
     array([[[nan],
             [1. ],
             [2. ]]])


### PR DESCRIPTION
This is a redo of #175; rebasing to the dev branch got hairy so I'm just making a new PR along with the suggested additions from https://github.com/rtavenar/tslearn/pull/175#issuecomment-571482396

-----------

If a time series with any `NaN` values is passed to `TimeSeriesScalerMeanVariance.fit_transform()` or `TimeSeriesScalerMinMax.fit_transform()` the transformed time series returns as all `NaN`

E.g:
```
In [1]: from tslearn.preprocessing import TimeSeriesScalerMeanVariance                                                                

In [2]: from numpy import nan                                                                                                         

In [3]: TimeSeriesScalerMeanVariance().fit_transform([0, nan, 6])                                                                     
Out[3]: 
array([[[nan],
        [nan],
        [nan]]])
```

This could be fixed by using the `NaN` disregarding `numpy` equivalent functions in the respective `transform` methods. This also makes tslearn in line with sklearn in terms of NaN's and preprocessing: https://github.com/scikit-learn/scikit-learn/issues/10404 