### PR TITLE
Add overwrite support to hdf5 model

### DIFF
--- a/tslearn/bases.py
+++ b/tslearn/bases.py
@@ -132,7 +132,7 @@ class BaseModelPackage:
 
         return inst
 
-    def to_hdf5(self, path):
+    def to_hdf5(self, path, over_write=False):
         """
         Save model to a HDF5 file.
         Requires ``h5py`` http://docs.h5py.org/
@@ -141,6 +141,9 @@ class BaseModelPackage:
         ----------
         path : str
             Full file path. File must not already exist.
+        
+        over_write : bool (default: False)
+            If True: overwrite the existing file in given path.
 
         Raises
         ------
@@ -151,7 +154,7 @@ class BaseModelPackage:
             raise ImportError(h5py_msg)
 
         d = self._to_dict(output='hdf5')
-        hdftools.save_dict(d, path, 'data')
+        hdftools.save_dict(d, path, 'data', over_write)
 
     @classmethod
     def from_hdf5(cls, path):

--- a/tslearn/hdftools.py
+++ b/tslearn/hdftools.py
@@ -5,7 +5,7 @@ import traceback
 from warnings import warn
 
 
-def save_dict(d, filename, group, raise_type_fail=True):
+def save_dict(d, filename, group, raise_type_fail=True, over_write=False):
     """
     Recursively save a dict to an hdf5 group in a new file.
 
@@ -24,6 +24,9 @@ def save_dict(d, filename, group, raise_type_fail=True):
         If True: raise an exception if saving a part of the dict fails.
         If False: prints a warning instead and saves the
         object's __str__() return value.
+        
+    over_write : bool (default: False)
+        If True: overwrite the existing file in given filename
 
     Returns
     -------

--- a/tslearn/hdftools.py
+++ b/tslearn/hdftools.py
@@ -35,14 +35,14 @@ def save_dict(d, filename, group, raise_type_fail=True, over_write=False):
     Raises
     ------
     FileExistsError
-        If the path specified by the `filename` parameter already exists.
+        If the path specified by the `filename` parameter already exists and over_write is set to False.
 
     TypeError
         If a particular entry within the dict cannot be saved to hdf5 AND
         the argument `raise_type_fail` is set to `True`
     """
 
-    if os.path.isfile(filename):
+    if not over_write and os.path.isfile(filename):
         raise FileExistsError
 
     with h5py.File(filename, 'w') as h5file:


### PR DESCRIPTION
At the moment, can't overwrite existing model files. IMHO it would be great if users can overwrite the existing files without changing the name.