### PR TITLE
Fixed a bug that ignored the user-specified gamma value with TimeSeriesSVC and TimeSeriesSVR and gak kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 Changelogs for this project are recorded in this file since v0.2.0.
 
+## [v0.3.1]
+
+### Fixed
+
+* Fixed a bug in `TimeSeriesSVC` and `TimeSeriesSVR` that caused user-input 
+`gamma` to be ignored (always treated as if it were `"auto"`) for `gak` kernel
+
 ## [v0.3.0]
 
 ### Changed

--- a/tslearn/svm.py
+++ b/tslearn/svm.py
@@ -45,7 +45,10 @@ class TimeSeriesSVMMixin:
 
         if fit_time:
             self._X_fit = X
-            self.gamma_ = gamma_soft_dtw(X)
+            if self.gamma == "auto":
+                self.gamma_ = gamma_soft_dtw(X)
+            else:
+                self.gamma_ = self.gamma
             self.classes_ = numpy.unique(y)
 
         if self.kernel in VARIABLE_LENGTH_METRICS:

--- a/tslearn/tests/test_svm.py
+++ b/tslearn/tests/test_svm.py
@@ -1,22 +1,24 @@
 import numpy as np
 
 from tslearn.metrics import cdist_gak
-from tslearn.svm import TimeSeriesSVC
+from tslearn.svm import TimeSeriesSVC, TimeSeriesSVR
 
 __author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
 
 
-def test_svm_gak():
-    n, sz, d = 15, 10, 3
+def test_gamma_value_svm():
+    n, sz, d = 5, 10, 3
     rng = np.random.RandomState(0)
     time_series = rng.randn(n, sz, d)
     labels = rng.randint(low=0, high=2, size=n)
 
     gamma = 10.
-    gak_km = TimeSeriesSVC(kernel="gak", gamma=gamma)
-    sklearn_X, _ = gak_km._preprocess_sklearn(time_series, labels,
-                                              fit_time=True)
+    for ModelClass in [TimeSeriesSVC, TimeSeriesSVR]:
+        gak_model = ModelClass(kernel="gak", gamma=gamma)
+        sklearn_X, _ = gak_model._preprocess_sklearn(time_series,
+                                                     labels,
+                                                     fit_time=True)
 
-    cdist_mat = cdist_gak(time_series, sigma=np.sqrt(gamma / 2.))
+        cdist_mat = cdist_gak(time_series, sigma=np.sqrt(gamma / 2.))
 
-    np.testing.assert_allclose(sklearn_X, cdist_mat)
+        np.testing.assert_allclose(sklearn_X, cdist_mat)

--- a/tslearn/tests/test_svm.py
+++ b/tslearn/tests/test_svm.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+from tslearn.metrics import cdist_gak
+from tslearn.svm import TimeSeriesSVC
+
+__author__ = 'Romain Tavenard romain.tavenard[at]univ-rennes2.fr'
+
+
+def test_svm_gak():
+    n, sz, d = 15, 10, 3
+    rng = np.random.RandomState(0)
+    time_series = rng.randn(n, sz, d)
+    labels = rng.randint(low=0, high=2, size=n)
+
+    gamma = 10.
+    gak_km = TimeSeriesSVC(kernel="gak", gamma=gamma)
+    sklearn_X, _ = gak_km._preprocess_sklearn(time_series, labels,
+                                              fit_time=True)
+
+    cdist_mat = cdist_gak(time_series, sigma=np.sqrt(gamma / 2.))
+
+    np.testing.assert_allclose(sklearn_X, cdist_mat)


### PR DESCRIPTION
Hi there,

When improving the doc examples, I found out that gamma was not set properly by `TimeSeriesSVC` and `TimeSeriesSVR` when the "gak" kernel was used.

@GillesVandewiele @johannfaouzi can any of you check that this was indeed a bug?
If it was, I would suggest we merge that PR to master and integrate the bugfix in the next patch release.