### PR TITLE
Improve the documentation and examples on barycenters

### DIFF
--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -7,8 +7,9 @@ A barycenter (or *Fréchet mean*) is a time series which minimizes some
 distance metric to the time series of a given data set, much like a
 centroid minimizes the (euclidean) distances to a set of points.
 
-Only the methods :func:`dtw_barycenter_averaging` and :func:`softdtw_barycenter`
-can operate on variable-length time-series (see :ref:`here<variable-length-barycenter>`).
+Only the methods :func:`dtw_barycenter_averaging` and
+:func:`softdtw_barycenter` can operate on variable-length time-series
+(see :ref:`here<variable-length-barycenter>`).
 
 See the :ref:`barycenter examples<sphx_glr_auto_examples_plot_barycenters.py>`
 for an overview over the four available methods.

--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -3,16 +3,17 @@
 The :mod:`tslearn.barycenters` module gathers algorithms for time series
 barycenter computation.
 
-A barycenter (or *Fréchet mean*) is a time series which minimizes some
-distance metric to the time series of a given data set, much like a
-centroid minimizes the (euclidean) distances to a set of points.
+A barycenter (or *Fréchet mean*) is a time series :math:`b` which minimizes
+the sum of distances to the time series of a given data set :math:`x`:
+
+.. math:: \\min \\sum_i d^2( b, x_i )
 
 Only the methods :func:`dtw_barycenter_averaging` and
 :func:`softdtw_barycenter` can operate on variable-length time-series
 (see :ref:`here<variable-length-barycenter>`).
 
 See the :ref:`barycenter examples<sphx_glr_auto_examples_plot_barycenters.py>`
-for an overview over the four available methods.
+for an overview.
 """
 
 # Code for soft DTW is by Mathieu Blondel under Simplified BSD license
@@ -833,6 +834,8 @@ def softdtw_barycenter(X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3,
                        max_iter=50, init=None):
     """Compute barycenter (time series averaging) under the soft-DTW geometry.
 
+    Soft-DTW was originally presented in [1]_.
+
     Parameters
     ----------
     X : array-like, shape=(n_ts, sz, d)
@@ -875,6 +878,11 @@ def softdtw_barycenter(X, gamma=1.0, weights=None, method="L-BFGS-B", tol=1e-3,
            [2.67573269],
            [3.51057026],
            [4.33645802]])
+
+    References
+    ----------
+    .. [1] M. Cuturi, M. Blondel “Soft-DTW: a Differentiable Loss Function for
+       Time-Series,” ICML 2017.
     """
     X_ = to_time_series_dataset(X)
     weights = _set_weights(weights, X_.shape[0])

--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -4,9 +4,9 @@ The :mod:`tslearn.barycenters` module gathers algorithms for time series
 barycenter computation.
 
 A barycenter (or *Fréchet mean*) is a time series :math:`b` which minimizes
-the sum of distances to the time series of a given data set :math:`x`:
+the sum of squared distances to the time series of a given data set :math:`x`:
 
-.. math:: \\min \\sum_i d^2( b, x_i )
+.. math:: \\min \\sum_i d( b, x_i )^2
 
 Only the methods :func:`dtw_barycenter_averaging` and
 :func:`softdtw_barycenter` can operate on variable-length time-series

--- a/tslearn/barycenters.py
+++ b/tslearn/barycenters.py
@@ -1,6 +1,17 @@
+# -*- coding: utf-8 -*-
 """
 The :mod:`tslearn.barycenters` module gathers algorithms for time series
 barycenter computation.
+
+A barycenter (or *Fréchet mean*) is a time series which minimizes some
+distance metric to the time series of a given data set, much like a
+centroid minimizes the (euclidean) distances to a set of points.
+
+Only the methods :func:`dtw_barycenter_averaging` and :func:`softdtw_barycenter`
+can operate on variable-length time-series (see :ref:`here<variable-length-barycenter>`).
+
+See the :ref:`barycenter examples<sphx_glr_auto_examples_plot_barycenters.py>`
+for an overview over the four available methods.
 """
 
 # Code for soft DTW is by Mathieu Blondel under Simplified BSD license

--- a/tslearn/docs/dtw.rst
+++ b/tslearn/docs/dtw.rst
@@ -1,3 +1,5 @@
+.. _dtw:
+
 Dynamic Time Warping
 ====================
 

--- a/tslearn/docs/examples/plot_barycenters.py
+++ b/tslearn/docs/examples/plot_barycenters.py
@@ -18,19 +18,26 @@ set of time series:
 * *DTW Barycenter Averaging (DBA)* is an iteratively refined barycenter,
   starting out with a (potentially) bad candidate and improving it
   until convergence criteria are met. The optimization can be accomplished
-  with (a) expectation-maximization and (b) stochastic subgradient descent.
-  Empirically, the latter "is [often] more stable and finds better
-  solutions in shorter time" [1].
+  with (a) expectation-maximization [1] and (b) stochastic subgradient
+  descent [2]. Empirically, the latter "is [often] more stable and finds better
+  solutions in shorter time" [2].
 * *Soft-DTW barycenter* uses a differentiable loss function to iteratively
-  find a barycenter. The method itself and the parameter :math:`\\gamma=1.0` is
-  described in more detail in the section on :ref:`DTW<dtw>`. There is also a
-  dedicated
+  find a barycenter [3]. The method itself and the parameter
+  :math:`\\gamma=1.0` is described in more detail in the section on
+  :ref:`DTW<dtw>`. There is also a dedicated
   :ref:`example<sphx_glr_auto_examples_plot_barycenter_interpolate.py>`
   available.
 
-[1] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
+[1] F. Petitjean, A. Ketterlin & P. Gancarski. A global averaging method
+for dynamic time warping, with applications to clustering. Pattern
+Recognition, Elsevier, 2011, Vol. 44, Num. 3, pp. 678-693
+
+[2] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
 for Averaging in Dynamic Time Warping Spaces.
 Pattern Recognition, 74, 340-358.
+
+[3] M. Cuturi, M. Blondel “Soft-DTW: a Differentiable Loss Function for
+Time-Series,” ICML 2017.
 """
 
 # Author: Romain Tavenard, Felix Divo

--- a/tslearn/docs/examples/plot_barycenters.py
+++ b/tslearn/docs/examples/plot_barycenters.py
@@ -7,8 +7,8 @@ This example shows three methods to compute barycenters of time series.
 For an overview over the available methods see the :mod:`tslearn.barycenters`
 module.
 
-*tslearn* provides three methods for calculating barycenters for a given
-set of time series:
+*tslearn* provides three methods for calculating barycenters for a given set of
+time series:
 
 * *Euclidean barycenter* is simply the arithmetic mean for
   each individual point in time, minimizing the summed euclidean distance
@@ -28,16 +28,15 @@ set of time series:
   :ref:`example<sphx_glr_auto_examples_plot_barycenter_interpolate.py>`
   available.
 
-[1] F. Petitjean, A. Ketterlin & P. Gancarski. A global averaging method
-for dynamic time warping, with applications to clustering. Pattern
-Recognition, Elsevier, 2011, Vol. 44, Num. 3, pp. 678-693
+[1] F. Petitjean, A. Ketterlin & P. Gancarski. A global averaging method for
+dynamic time warping, with applications to clustering. Pattern Recognition,
+Elsevier, 2011, Vol. 44, Num. 3, pp. 678-693.
 
-[2] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
-for Averaging in Dynamic Time Warping Spaces.
-Pattern Recognition, 74, 340-358.
+[2] D. Schultz & B. Jain. Nonsmooth Analysis and Subgradient Methods for
+Averaging in Dynamic Time Warping Spaces. Pattern Recognition, 74, 340-358.
 
-[3] M. Cuturi, M. Blondel “Soft-DTW: a Differentiable Loss Function for
-Time-Series,” ICML 2017.
+[3] M. Cuturi & M. Blondel. Soft-DTW: a Differentiable Loss Function for
+Time-Series. ICML 2017.
 """
 
 # Author: Romain Tavenard, Felix Divo

--- a/tslearn/docs/examples/plot_barycenters.py
+++ b/tslearn/docs/examples/plot_barycenters.py
@@ -4,50 +4,83 @@ Barycenters
 ===========
 
 This example shows three methods to compute barycenters of time series.
+For an overview over the available methods see the :mod:`tslearn.barycenters`
+module.
+
+*tslearn* provides three methods for calculating barycenters for a given
+set of time series:
+
+* *Euclidean barycenter* is simply the arithmetic mean for
+  each individual point in time, minimizing the summed euclidean distance
+  for each of them. As can be seen below, it is very different from the
+  DTW-based methods and may often be inappropriate. However, it is the
+  fastest of the methods shown.
+* *DTW Barycenter Averaging (DBA)* is an iteratively refined barycenter,
+  starting out with a (potentially) very bad candidate and improving it
+  until convergence criteria are met, optionally trying multiple
+  initializations. The optimization can be accomplished with (a)
+  expectation-maximization and (b) stochastic subgradient descent.
+  Empirically, the latter "is [often] more stable and finds better
+  solutions in shorter time" [1].
+* *Soft-DTW barycenter* uses a differentiable loss function to iteratively
+  find a barycenter. The method itself and the parameter :math:`\gamma=1.0` is
+  described in more detail in the section on :ref:`DTW<dtw>`. There is also a
+  :ref:`dedicated example<sphx_glr_auto_examples_plot_barycenter_interpolate.py>`
+  available.
+
+[1] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
+for Averaging in Dynamic Time Warping Spaces.
+Pattern Recognition, 74, 340-358.
 """
 
-# Author: Romain Tavenard
+# Author: Romain Tavenard, Felix Divo
 # License: BSD 3 clause
 
 import numpy
 import matplotlib.pyplot as plt
 
-from tslearn.barycenters import euclidean_barycenter, \
-    dtw_barycenter_averaging, dtw_barycenter_averaging_subgradient, \
+from tslearn.barycenters import \
+    euclidean_barycenter, \
+    dtw_barycenter_averaging, \
+    dtw_barycenter_averaging_subgradient, \
     softdtw_barycenter
 from tslearn.datasets import CachedDatasets
 
+# fetch the example data set
 numpy.random.seed(0)
-X_train, y_train, X_test, y_test = CachedDatasets().load_dataset("Trace")
+X_train, y_train, _, _ = CachedDatasets().load_dataset("Trace")
 X = X_train[y_train == 2]
+length_of_sequence = X.shape[1]
 
-plt.figure()
-plt.subplot(4, 1, 1)
-for ts in X:
-    plt.plot(ts.ravel(), "k-", alpha=.2)
-plt.plot(euclidean_barycenter(X).ravel(), "r-", linewidth=2)
+
+def plot_helper(barycenter):
+    # plot all points of the data set
+    for series in X:
+        plt.plot(series.ravel(), "k-", alpha=.2)
+    # plot the given barycenter of them
+    plt.plot(barycenter.ravel(), "r-", linewidth=2)
+
+
+# plot the four variants
+ax1 = plt.subplot(4, 1, 1)
 plt.title("Euclidean barycenter")
+plot_helper(euclidean_barycenter(X))
 
-plt.subplot(4, 1, 2)
-dba_bar = dtw_barycenter_averaging(X, max_iter=100, verbose=False)
-for ts in X:
-    plt.plot(ts.ravel(), "k-", alpha=.2)
-plt.plot(dba_bar.ravel(), "r-", linewidth=2)
+plt.subplot(4, 1, 2, sharex=ax1)
 plt.title("DBA (vectorized version of Petitjean's EM)")
+plot_helper(dtw_barycenter_averaging(X, max_iter=100))
 
-plt.subplot(4, 1, 3)
-dba_bar = dtw_barycenter_averaging_subgradient(X, max_iter=100, verbose=False)
-for ts in X:
-    plt.plot(ts.ravel(), "k-", alpha=.2)
-plt.plot(dba_bar.ravel(), "r-", linewidth=2)
+plt.subplot(4, 1, 3, sharex=ax1)
 plt.title("DBA (subgradient descent approach)")
+plot_helper(dtw_barycenter_averaging_subgradient(X, max_iter=100))
 
-plt.subplot(4, 1, 4)
-sdtw_bar = softdtw_barycenter(X, gamma=1., max_iter=100)
-for ts in X:
-    plt.plot(ts.ravel(), "k-", alpha=.2)
-plt.plot(sdtw_bar.ravel(), "r-", linewidth=2)
-plt.title("Soft-DTW barycenter ($\gamma$=1.)")
+plt.subplot(4, 1, 4, sharex=ax1)
+plt.title("Soft-DTW barycenter ($\gamma$=1.0)")
+plot_helper(softdtw_barycenter(X, gamma=1., max_iter=100))
 
+# clip the axes for better readability
+ax1.set_xlim([0, length_of_sequence])
+
+# show the plot(s)
 plt.tight_layout()
 plt.show()

--- a/tslearn/docs/examples/plot_barycenters.py
+++ b/tslearn/docs/examples/plot_barycenters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-r"""
+"""
 Barycenters
 ===========
 
@@ -22,7 +22,7 @@ set of time series:
   Empirically, the latter "is [often] more stable and finds better
   solutions in shorter time" [1].
 * *Soft-DTW barycenter* uses a differentiable loss function to iteratively
-  find a barycenter. The method itself and the parameter :math:`\gamma=1.0` is
+  find a barycenter. The method itself and the parameter :math:`\\gamma=1.0` is
   described in more detail in the section on :ref:`DTW<dtw>`. There is also a
   dedicated
   :ref:`example<sphx_glr_auto_examples_plot_barycenter_interpolate.py>`

--- a/tslearn/docs/examples/plot_barycenters.py
+++ b/tslearn/docs/examples/plot_barycenters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
+r"""
 Barycenters
 ===========
 
@@ -16,16 +16,16 @@ set of time series:
   DTW-based methods and may often be inappropriate. However, it is the
   fastest of the methods shown.
 * *DTW Barycenter Averaging (DBA)* is an iteratively refined barycenter,
-  starting out with a (potentially) very bad candidate and improving it
-  until convergence criteria are met, optionally trying multiple
-  initializations. The optimization can be accomplished with (a)
-  expectation-maximization and (b) stochastic subgradient descent.
+  starting out with a (potentially) bad candidate and improving it
+  until convergence criteria are met. The optimization can be accomplished
+  with (a) expectation-maximization and (b) stochastic subgradient descent.
   Empirically, the latter "is [often] more stable and finds better
   solutions in shorter time" [1].
 * *Soft-DTW barycenter* uses a differentiable loss function to iteratively
   find a barycenter. The method itself and the parameter :math:`\gamma=1.0` is
   described in more detail in the section on :ref:`DTW<dtw>`. There is also a
-  :ref:`dedicated example<sphx_glr_auto_examples_plot_barycenter_interpolate.py>`
+  dedicated
+  :ref:`example<sphx_glr_auto_examples_plot_barycenter_interpolate.py>`
   available.
 
 [1] D. Schultz and B. Jain. Nonsmooth Analysis and Subgradient Methods
@@ -61,22 +61,23 @@ def plot_helper(barycenter):
     plt.plot(barycenter.ravel(), "r-", linewidth=2)
 
 
-# plot the four variants
+# plot the four variants with the same number of iterations and a tolerance of
+# 1e-3 where applicable
 ax1 = plt.subplot(4, 1, 1)
 plt.title("Euclidean barycenter")
 plot_helper(euclidean_barycenter(X))
 
 plt.subplot(4, 1, 2, sharex=ax1)
 plt.title("DBA (vectorized version of Petitjean's EM)")
-plot_helper(dtw_barycenter_averaging(X, max_iter=100))
+plot_helper(dtw_barycenter_averaging(X, max_iter=50, tol=1e-3))
 
 plt.subplot(4, 1, 3, sharex=ax1)
 plt.title("DBA (subgradient descent approach)")
-plot_helper(dtw_barycenter_averaging_subgradient(X, max_iter=100))
+plot_helper(dtw_barycenter_averaging_subgradient(X, max_iter=50, tol=1e-3))
 
 plt.subplot(4, 1, 4, sharex=ax1)
 plt.title("Soft-DTW barycenter ($\gamma$=1.0)")
-plot_helper(softdtw_barycenter(X, gamma=1., max_iter=100))
+plot_helper(softdtw_barycenter(X, gamma=1., max_iter=50, tol=1e-3))
 
 # clip the axes for better readability
 ax1.set_xlim([0, length_of_sequence])

--- a/tslearn/docs/variablelength.rst
+++ b/tslearn/docs/variablelength.rst
@@ -95,10 +95,11 @@ Examples
     labels = km.fit_predict(X)
     silhouette_score(X, labels, metric="dtw")
 
+.. _variable-length-barycenter:
+
 Barycenter computation
 ----------------------
 
-.. _variable-length-barycenter
 
 * :ref:`dtw_barycenter_averaging <fun-tslearn.barycenters.dtw_barycenter_averaging>`
 * :ref:`softdtw_barycenter <fun-tslearn.barycenters.softdtw_barycenter>`

--- a/tslearn/docs/variablelength.rst
+++ b/tslearn/docs/variablelength.rst
@@ -98,6 +98,8 @@ Examples
 Barycenter computation
 ----------------------
 
+.. _variable-length-barycenter
+
 * :ref:`dtw_barycenter_averaging <fun-tslearn.barycenters.dtw_barycenter_averaging>`
 * :ref:`softdtw_barycenter <fun-tslearn.barycenters.softdtw_barycenter>`
 


### PR DESCRIPTION
These are the changes:

#### General:
- better overview in the `tslearn.barycenter` module
- that module now links to the `plot_barycenter.py` example

#### On `plot_barycenter.py`:
- textual overview over the four methods added
- some inline comments + code is shorter
- all methods use the same number of iterations and tolerance for early stopping
- the plot is visually a little bit nicer
- get rid of the convergence warning of `dtw_barycenter_averaging_subgradient()` [still TODO]
