### PR TITLE
[WIP] Better kmeans initialization

### DIFF
--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -103,7 +103,7 @@ def _k_init_metric(X, n_clusters, cdist_metric, random_state,
                    out=candidate_ids)
 
         # Compute distances to center candidates
-        distance_to_candidates = cdist_metric(centers[candidate_ids], X) ** 2
+        distance_to_candidates = cdist_metric(X[candidate_ids], X) ** 2
 
         # update closest distances squared and potential for each candidate
         numpy.minimum(closest_dist_sq, distance_to_candidates,

--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -790,37 +790,23 @@ class TimeSeriesKMeans(BaseEstimator, BaseModelPackage, ClusterMixin,
                     x_squared_norms,
                     rs
                 ).reshape((-1, sz, d))
-            elif self.metric == "dtw":
-                metric_fun = lambda x, y: cdist_dtw(
-                    x,
-                    y,
-                    n_jobs=self.n_jobs,
-                    verbose=self.verbose,
-                    **metric_params
-                )
-                self.cluster_centers_ = _k_init_metric(
-                    X,
-                    self.n_clusters,
-                    cdist_metric=metric_fun,
-                    random_state=rs
-                )
-            elif self.metric == "softdtw":
-                metric_fun = lambda x, y: cdist_soft_dtw(
-                    x,
-                    y,
-                    **metric_params
-                )
-                self.cluster_centers_ = _k_init_metric(
-                    X,
-                    self.n_clusters,
-                    cdist_metric=metric_fun,
-                    random_state=rs
-                )
             else:
-                raise ValueError(
-                    "Incorrect metric: %s (should be one of 'dtw', "
-                    "'softdtw', 'euclidean')" % self.metric
-                )
+                if self.metric == "dtw":
+                    def metric_fun(x, y):
+                        return cdist_dtw(x, y, n_jobs=self.n_jobs,
+                                         verbose=self.verbose, **metric_params)
+
+                elif self.metric == "softdtw":
+                    def metric_fun(x, y):
+                        return cdist_soft_dtw(x, y, **metric_params)
+                else:
+                    raise ValueError(
+                        "Incorrect metric: %s (should be one of 'dtw', "
+                        "'softdtw', 'euclidean')" % self.metric
+                    )
+                self.cluster_centers_ = _k_init_metric(X, self.n_clusters,
+                                                       cdist_metric=metric_fun,
+                                                       random_state=rs)
         elif self.init == "random":
             indices = rs.choice(X.shape[0], self.n_clusters)
             self.cluster_centers_ = X[indices].copy()

--- a/tslearn/clustering.py
+++ b/tslearn/clustering.py
@@ -40,9 +40,8 @@ def _k_init_metric(X, n_clusters, cdist_metric, random_state,
 
     Parameters
     ----------
-    X : array or sparse matrix, shape (n_samples, n_features)
-        The data to pick seeds for. To avoid memory copy, the input data
-        should be double precision (dtype=np.float64).
+    X : array, shape (n_samples, n_timestamps, n_features)
+        The data to pick seeds for.
 
     n_clusters : integer
         The number of seeds to choose
@@ -83,10 +82,7 @@ def _k_init_metric(X, n_clusters, cdist_metric, random_state,
 
     # Pick first center randomly
     center_id = random_state.randint(n_samples)
-    if sp.issparse(X):
-        centers[0] = X[center_id].toarray()
-    else:
-        centers[0] = X[center_id]
+    centers[0] = X[center_id]
 
     # Initialize list of closest distances and calculate current potential
     closest_dist_sq = cdist_metric(centers[0, numpy.newaxis], X) ** 2
@@ -118,10 +114,7 @@ def _k_init_metric(X, n_clusters, cdist_metric, random_state,
         best_candidate = candidate_ids[best_candidate]
 
         # Permanently add best center candidate found in local tries
-        if sp.issparse(X):
-            centers[c] = X[best_candidate].toarray()
-        else:
-            centers[c] = X[best_candidate]
+        centers[c] = X[best_candidate]
 
     return centers
 

--- a/tslearn/preprocessing.py
+++ b/tslearn/preprocessing.py
@@ -50,6 +50,13 @@ class TimeSeriesResampler(TransformerMixin):
         """
         return self
 
+    def _transform_unit_sz(self, X):
+        n_ts, sz, d = X.shape
+        X_out = numpy.empty((n_ts, self.sz_, d))
+        for i in range(X.shape[0]):
+            X_out[i] = numpy.nanmean(X[i], axis=0, keepdims=True)
+        return X_out
+
     def transform(self, X, **kwargs):
         """Fit to data, then transform it.
 
@@ -64,6 +71,8 @@ class TimeSeriesResampler(TransformerMixin):
             Resampled time series dataset.
         """
         X_ = to_time_series_dataset(X)
+        if self.sz_ == 1:
+            return self._transform_unit_sz(X_)
         n_ts, sz, d = X_.shape
         equal_size = check_equal_size(X_)
         X_out = numpy.empty((n_ts, self.sz_, d))

--- a/tslearn/tests/test_clustering.py
+++ b/tslearn/tests/test_clustering.py
@@ -121,6 +121,7 @@ def test_kmeans():
                                     [1., 2., 2., 3., 4.],
                                     [3., 2., 1.]])
     sizes_all_same_bary = [barys.shape[1]] * n_clusters
+    # If Euclidean is used, barycenters size should be that of the input series
     km_euc = TimeSeriesKMeans(n_clusters=3,
                               metric="euclidean",
                               max_iter=5,
@@ -128,6 +129,7 @@ def test_kmeans():
                               init=barys,
                               random_state=rng)
     np.testing.assert_raises(ValueError, km_euc.fit, time_series)
+
     km_dba = TimeSeriesKMeans(n_clusters=3,
                               metric="dtw",
                               max_iter=5,
@@ -160,6 +162,3 @@ def test_kshape():
 
     assert KShape(n_clusters=101, verbose=False,
                   random_state=rng).fit(time_series)._X_fit is None
-
-# if __name__ == "__main__":
-#     test_kmeans()

--- a/tslearn/tests/test_clustering.py
+++ b/tslearn/tests/test_clustering.py
@@ -147,6 +147,21 @@ def test_kmeans():
     np.testing.assert_equal(sizes_all_same_bary,
                             [ts_size(b) for b in km_sdtw.cluster_centers_])
 
+    # A simple dataset, can we extract the correct number of clusters?
+    time_series = to_time_series_dataset([[1, 2, 3],
+                                   [7, 8, 9, 11],
+                                   [.1, .2, 2.],
+                                   [1, 1, 1, 9],
+                                   [10, 20, 30, 1000]])
+    preds = TimeSeriesKMeans(n_clusters=3, metric="dtw", max_iter=5,
+                             random_state=rng).fit_predict(time_series)
+    np.testing.assert_equal(set(preds), set(range(3)))
+    preds = TimeSeriesKMeans(n_clusters=4, metric="dtw", max_iter=5,
+                             random_state=rng).fit_predict(time_series)
+    np.testing.assert_equal(set(preds), set(range(4)))
+
+
+
 
 def test_kshape():
     n, sz, d = 15, 10, 3

--- a/tslearn/tests/test_clustering.py
+++ b/tslearn/tests/test_clustering.py
@@ -91,6 +91,9 @@ def test_kmeans():
     TimeSeriesKMeans(n_clusters=2, verbose=False, max_iter=5,
                      metric="dtw", init=X_bis[:2]).fit(X_bis)
 
+    # TODO: add a check that ensures that cluster centers maintain their
+    # lengths along kmeans iterations even if DTW/softDTW are used as metrics
+
 
 def test_kshape():
     n, sz, d = 15, 10, 3


### PR DESCRIPTION
This PR is a follow-up to Issue #215 .

The point is that it makes little sense to compute initial centroids using kmeans++ based on euclidean distances if the clustering is intended to be run wrt DTW or softDTW. So this PR adds a custom `_k_init` (adaptation from the one in scikit-learn) to the clustering module that draws samples wrt the target metric.